### PR TITLE
Add comprehensive GUI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ streamlit run streamlit_app.py
 
 ## Running Tests
 
+To run all tests:
+
 ```bash
 pytest
+```
+
+To run only the GUI tests:
+
+```bash
+pytest tests/test_gui.py
 ```

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -2,70 +2,102 @@ import streamlit as st
 import requests
 from datetime import datetime
 
-API_URL = 'http://localhost:8000'
+API_URL = "http://localhost:8000"
 
-st.title('Calendar App')
+st.title("Calendar App")
 
-if 'appointments' not in st.session_state:
-    st.session_state['appointments'] = []
+if "appointments" not in st.session_state:
+    st.session_state["appointments"] = []
+
 
 def refresh():
-    resp = requests.get(f'{API_URL}/appointments')
+    resp = requests.get(f"{API_URL}/appointments")
     if resp.status_code == 200:
-        st.session_state['appointments'] = resp.json()
+        st.session_state["appointments"] = resp.json()
 
-if st.button('Refresh'):
+
+if st.button("Refresh", key="refresh-btn"):
     refresh()
 
-st.header('Create Appointment')
-with st.form('create'):
-    title = st.text_input('Title')
-    description = st.text_input('Description')
-    start = st.datetime_input('Start Time')
-    end = st.datetime_input('End Time')
-    submitted = st.form_submit_button('Create')
+st.header("Create Appointment")
+with st.form("create-form"):
+    title = st.text_input("Title", key="create-title")
+    description = st.text_input("Description", key="create-description")
+    start_date = st.date_input("Start Date", key="create-start-date")
+    start_time = st.time_input("Start Time", key="create-start-time")
+    end_date = st.date_input("End Date", key="create-end-date")
+    end_time = st.time_input("End Time", key="create-end-time")
+    submitted = st.form_submit_button("Create")
     if submitted:
+        start = datetime.combine(start_date, start_time)
+        end = datetime.combine(end_date, end_time)
         data = {
-            'title': title,
-            'description': description,
-            'start_time': start.isoformat(),
-            'end_time': end.isoformat()
+            "title": title,
+            "description": description,
+            "start_time": start.isoformat(),
+            "end_time": end.isoformat(),
         }
-        resp = requests.post(f'{API_URL}/appointments', json=data)
+        resp = requests.post(f"{API_URL}/appointments", json=data)
         if resp.status_code == 200:
-            st.success('Created')
+            st.success("Created")
             refresh()
         else:
-            st.error('Error creating appointment')
+            st.error("Error creating appointment")
 
-st.header('Appointments')
-for appt in st.session_state['appointments']:
-    with st.expander(appt['title']):
+st.header("Appointments")
+for appt in st.session_state["appointments"]:
+    with st.expander(appt["title"]):
         st.write(f"Start: {appt['start_time']}")
         st.write(f"End: {appt['end_time']}")
-        st.write(appt.get('description', ''))
-        with st.form(f'edit_{appt["id"]}'):
-            title = st.text_input('Title', value=appt['title'])
-            description = st.text_input('Description', value=appt.get('description', ''))
-            start = st.datetime_input('Start Time', value=datetime.fromisoformat(appt['start_time']))
-            end = st.datetime_input('End Time', value=datetime.fromisoformat(appt['end_time']))
-            if st.form_submit_button('Update'):
+        st.write(appt.get("description", ""))
+        with st.form(f'edit-form-{appt["id"]}'):
+            title = st.text_input(
+                "Title", value=appt["title"], key=f'title_{appt["id"]}'
+            )
+            description = st.text_input(
+                "Description",
+                value=appt.get("description", ""),
+                key=f'desc_{appt["id"]}',
+            )
+            start_date = st.date_input(
+                "Start Date",
+                value=datetime.fromisoformat(appt["start_time"]).date(),
+                key=f'start_date_{appt["id"]}',
+            )
+            start_time = st.time_input(
+                "Start Time",
+                value=datetime.fromisoformat(appt["start_time"]).time(),
+                key=f'start_time_{appt["id"]}',
+            )
+            end_date = st.date_input(
+                "End Date",
+                value=datetime.fromisoformat(appt["end_time"]).date(),
+                key=f'end_date_{appt["id"]}',
+            )
+            end_time = st.time_input(
+                "End Time",
+                value=datetime.fromisoformat(appt["end_time"]).time(),
+                key=f'end_time_{appt["id"]}',
+            )
+            if st.form_submit_button("Update"):
+                start = datetime.combine(start_date, start_time)
+                end = datetime.combine(end_date, end_time)
                 data = {
-                    'title': title,
-                    'description': description,
-                    'start_time': start.isoformat(),
-                    'end_time': end.isoformat()
+                    "title": title,
+                    "description": description,
+                    "start_time": start.isoformat(),
+                    "end_time": end.isoformat(),
                 }
                 resp = requests.put(f'{API_URL}/appointments/{appt["id"]}', json=data)
                 if resp.status_code == 200:
-                    st.success('Updated')
+                    st.success("Updated")
                     refresh()
                 else:
-                    st.error('Error updating')
-        if st.button('Delete', key=f'del_{appt["id"]}'):
+                    st.error("Error updating")
+        if st.button("Delete", key=f'del_{appt["id"]}'):
             resp = requests.delete(f'{API_URL}/appointments/{appt["id"]}')
             if resp.status_code == 200:
-                st.success('Deleted')
+                st.success("Deleted")
                 refresh()
             else:
-                st.error('Error deleting')
+                st.error("Error deleting")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,0 +1,72 @@
+import subprocess
+import time
+import os
+from datetime import date, time as dtime
+import requests
+from streamlit.testing.v1 import AppTest
+
+API_URL = "http://localhost:8000"
+
+
+def wait_for_api(url: str, timeout: float = 5.0):
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            if requests.get(url).status_code == 200:
+                return True
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.1)
+    return False
+
+
+def start_server():
+    if os.path.exists("appointments.db"):
+        os.remove("appointments.db")
+    proc = subprocess.Popen(["uvicorn", "app.main:app"])
+    assert wait_for_api(f"{API_URL}/appointments")
+    return proc
+
+
+def stop_server(proc):
+    proc.terminate()
+    proc.wait()
+    if os.path.exists("appointments.db"):
+        os.remove("appointments.db")
+
+
+def test_full_gui_interaction():
+    proc = start_server()
+    try:
+        at = AppTest.from_file("streamlit_app.py").run()
+
+        # create appointment
+        at = at.text_input(key="create-title").input("Meeting").run()
+        at = at.text_input(key="create-description").input("Discuss project").run()
+        at = at.date_input(key="create-start-date").set_value(date(2024, 1, 1)).run()
+        at = at.time_input(key="create-start-time").set_value(dtime(10, 0)).run()
+        at = at.date_input(key="create-end-date").set_value(date(2024, 1, 1)).run()
+        at = at.time_input(key="create-end-time").set_value(dtime(11, 0)).run()
+        at = at.button[1].click().run()
+        assert "Created" in [s.value for s in at.success]
+        at = at.button(key="refresh-btn").click().run()
+        assert any(e.label == "Meeting" for e in at.expander)
+
+        # update appointment
+        at = at.text_input(key="title_1").set_value("Updated Meeting").run()
+        at = at.text_input(key="desc_1").set_value("Updated notes").run()
+        at = at.date_input(key="start_date_1").set_value(date(2024, 1, 2)).run()
+        at = at.time_input(key="start_time_1").set_value(dtime(9, 0)).run()
+        at = at.date_input(key="end_date_1").set_value(date(2024, 1, 2)).run()
+        at = at.time_input(key="end_time_1").set_value(dtime(10, 0)).run()
+        at = at.button[2].click().run()
+        assert "Updated" in [s.value for s in at.success]
+        at = at.button(key="refresh-btn").click().run()
+        assert any(e.label == "Updated Meeting" for e in at.expander)
+
+        # delete appointment
+        at = at.button(key="del_1").click().run()
+        assert "Deleted" in [s.value for s in at.success]
+        at = at.button(key="refresh-btn").click().run()
+        assert len(at.expander) == 0
+    finally:
+        stop_server(proc)


### PR DESCRIPTION
## Summary
- fix Streamlit datetime inputs
- assign keys to widgets
- add Streamlit GUI test to verify full user workflow
- document running GUI tests separately

## Testing
- `pytest tests/test_gui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_687f747008cc832799805177f95c8ec9