### PR TITLE
Add autoinstaller with automatic dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ To run only the GUI tests:
 ```bash
 pytest tests/test_gui.py
 ```
+
+## Automatic Dependency Installation
+
+Importing the `autoinstaller` module installs any missing Python packages
+discovered in the project. Set `AUTOINSTALL_PATH` to scan a different directory
+before importing the module.

--- a/autoinstaller.py
+++ b/autoinstaller.py
@@ -1,0 +1,58 @@
+class AutoInstaller:
+    """Install missing dependencies found in Python files."""
+
+    def __init__(self) -> None:
+        from importlib.util import find_spec
+        from pathlib import Path
+        import os
+
+        path_str = os.getenv("AUTOINSTALL_PATH", Path(__file__).resolve().parent)
+        self.root = Path(path_str)
+        self._find_spec = find_spec
+        self._scan_and_install()
+
+    def _collect_files(self) -> list["Path"]:
+        from pathlib import Path
+
+        return [p for p in self.root.rglob("*.py") if p.is_file()]
+
+    def _parse_imports(self, file_path: "Path") -> set[str]:
+        import ast
+
+        modules: set[str] = set()
+        with file_path.open("r", encoding="utf-8") as f:
+            tree = ast.parse(f.read(), filename=str(file_path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for n in node.names:
+                    modules.add(n.name.split(".")[0])
+            elif isinstance(node, ast.ImportFrom):
+                if node.module and not node.level:
+                    modules.add(node.module.split(".")[0])
+        return modules
+
+    def _is_installed(self, module: str) -> bool:
+        return self._find_spec(module) is not None
+
+    def _install(self, module: str) -> None:
+        import subprocess
+        import sys
+
+        subprocess.run(
+            [sys.executable, "-m", "pip", "install", module],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def _scan_and_install(self) -> None:
+        modules: set[str] = set()
+        for path in self._collect_files():
+            modules.update(self._parse_imports(path))
+        for mod in modules:
+            if not self._is_installed(mod):
+                self._install(mod)
+
+
+AutoInstaller()
+

--- a/tests/test_autoinstaller.py
+++ b/tests/test_autoinstaller.py
@@ -1,0 +1,23 @@
+import importlib
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_autoinstaller_installs_packages(tmp_path, monkeypatch):
+    subprocess.run([sys.executable, "-m", "pip", "uninstall", "-y", "colorama"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+    target = tmp_path / "proj"
+    target.mkdir()
+    (target / "sample.py").write_text("import colorama\n", encoding="utf-8")
+
+    monkeypatch.setenv("AUTOINSTALL_PATH", str(target))
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+    if "autoinstaller" in sys.modules:
+        importlib.reload(sys.modules["autoinstaller"])
+    else:
+        import autoinstaller  # noqa: F401
+
+    assert importlib.util.find_spec("colorama") is not None
+


### PR DESCRIPTION
## Summary
- implement `autoinstaller` that scans python files for missing imports and installs them on import
- document autoinstaller usage in README
- test autoinstaller behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8815b63c8327b32b3e5c6e6fb76a