### PR TITLE
Add tasks management

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,13 @@
-from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Date,
+    Time,
+    Boolean,
+    ForeignKey,
+)
 from sqlalchemy.orm import relationship
 from .database import Base
 
@@ -20,3 +29,20 @@ class Appointment(Base):
     category = relationship("Category")
     start_time = Column(DateTime, nullable=False)
     end_time = Column(DateTime, nullable=False)
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    due_date = Column(Date, nullable=False)
+    start_date = Column(Date, nullable=True)
+    end_date = Column(Date, nullable=True)
+    start_time = Column(Time, nullable=True)
+    end_time = Column(Time, nullable=True)
+    perceived_difficulty = Column(Integer, nullable=True)
+    estimated_difficulty = Column(Integer, nullable=True)
+    worked_on = Column(Boolean, default=False)
+    paused = Column(Boolean, default=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, date, time
 from pydantic import BaseModel, ConfigDict
 
 
@@ -30,6 +30,34 @@ class AppointmentUpdate(AppointmentBase):
     pass
 
 class Appointment(AppointmentBase):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TaskBase(BaseModel):
+    title: str
+    description: str | None = None
+    due_date: date
+    start_date: date | None = None
+    end_date: date | None = None
+    start_time: time | None = None
+    end_time: time | None = None
+    perceived_difficulty: int | None = None
+    estimated_difficulty: int | None = None
+    worked_on: bool = False
+    paused: bool = False
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(TaskBase):
+    pass
+
+
+class Task(TaskBase):
     id: int
 
     model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
- implement Task model and pydantic schema
- add CRUD API endpoints for tasks
- extend Streamlit UI with new Manage Tasks tab
- integrate tasks with calendar view
- update API and GUI tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fb96f46c883279e1a5e4f26eca1f0