### PR TITLE
Add focus session feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 This project provides a simple calendar application with a REST API and a Streamlit GUI. Users can create, update, delete, and list appointments.
 It also supports managing tasks with optional subtasks. Subtasks are useful for breaking large tasks into smaller steps, which can be helpful for users with ADHD.
+Additionally, tasks now support **focus sessions** to encourage short, timed work intervals. This feature is designed with ADHD users in mind to aid concentration.
 
 ## Requirements
 
@@ -56,3 +57,12 @@ Subtasks are managed via the following endpoints:
 - `GET /tasks/{task_id}/subtasks` – list subtasks of a task
 - `PUT /tasks/{task_id}/subtasks/{subtask_id}` – update a subtask
 - `DELETE /tasks/{task_id}/subtasks/{subtask_id}` – delete a subtask
+
+## Focus Session API
+
+Focus sessions help break work into manageable chunks. Endpoints:
+
+- `POST /tasks/{task_id}/focus_sessions` – start a focus session
+- `GET /tasks/{task_id}/focus_sessions` – list focus sessions for a task
+- `PUT /tasks/{task_id}/focus_sessions/{session_id}` – update a focus session
+- `DELETE /tasks/{task_id}/focus_sessions/{session_id}` – delete a focus session

--- a/app/models.py
+++ b/app/models.py
@@ -48,6 +48,11 @@ class Task(Base):
     paused = Column(Boolean, default=False)
 
     subtasks = relationship("Subtask", back_populates="task", cascade="all, delete-orphan")
+    focus_sessions = relationship(
+        "FocusSession",
+        back_populates="task",
+        cascade="all, delete-orphan",
+    )
 
 
 class Subtask(Base):
@@ -58,3 +63,15 @@ class Subtask(Base):
     completed = Column(Boolean, default=False)
     task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
     task = relationship("Task", back_populates="subtasks")
+
+
+class FocusSession(Base):
+    __tablename__ = "focus_sessions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    task_id = Column(Integer, ForeignKey("tasks.id"), nullable=False)
+    start_time = Column(DateTime, nullable=False)
+    end_time = Column(DateTime, nullable=False)
+    completed = Column(Boolean, default=False)
+
+    task = relationship("Task", back_populates="focus_sessions")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -81,3 +81,25 @@ class Subtask(SubtaskBase):
     task_id: int
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class FocusSessionBase(BaseModel):
+    start_time: datetime
+    end_time: datetime
+    completed: bool = False
+
+
+class FocusSessionCreate(BaseModel):
+    duration_minutes: int
+
+
+class FocusSessionUpdate(BaseModel):
+    end_time: datetime | None = None
+    completed: bool | None = None
+
+
+class FocusSession(FocusSessionBase):
+    id: int
+    task_id: int
+
+    model_config = ConfigDict(from_attributes=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -144,3 +144,48 @@ def test_subtask_crud():
     r = requests.get(f"{API_URL}/tasks/{task['id']}/subtasks")
     assert r.status_code == 200
     assert r.json() == []
+
+
+def test_focus_session_crud():
+    task_data = {
+        "title": "Task",
+        "description": "Do something",
+        "due_date": "2024-01-05",
+        "start_date": "2024-01-04",
+        "end_date": "2024-01-04",
+        "start_time": "09:00:00",
+        "end_time": "10:00:00",
+        "perceived_difficulty": 2,
+        "estimated_difficulty": 3,
+        "worked_on": False,
+        "paused": False,
+    }
+    r = requests.post(f"{API_URL}/tasks", json=task_data)
+    assert r.status_code == 200
+    task = r.json()
+
+    fs_data = {"duration_minutes": 25}
+    r = requests.post(f"{API_URL}/tasks/{task['id']}/focus_sessions", json=fs_data)
+    assert r.status_code == 200
+    session = r.json()
+    assert session["task_id"] == task["id"]
+
+    r = requests.get(f"{API_URL}/tasks/{task['id']}/focus_sessions")
+    assert r.status_code == 200
+    assert len(r.json()) == 1
+
+    update = {"completed": True}
+    r = requests.put(
+        f"{API_URL}/tasks/{task['id']}/focus_sessions/{session['id']}",
+        json=update,
+    )
+    assert r.status_code == 200
+    assert r.json()["completed"] is True
+
+    r = requests.delete(
+        f"{API_URL}/tasks/{task['id']}/focus_sessions/{session['id']}"
+    )
+    assert r.status_code == 200
+    r = requests.get(f"{API_URL}/tasks/{task['id']}/focus_sessions")
+    assert r.status_code == 200
+    assert r.json() == []

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -73,6 +73,25 @@ def test_full_gui_interaction():
         assert "Created" in [s.value for s in at.success]
         at = at.tabs[1].button(key="refresh-tasks").click().run()
 
+        # create focus session
+        at = at.number_input(key="fs_dur_1").set_value(30).run()
+        at = at.button(key="fs_start_1").click().run()
+        assert "Created" in [s.value for s in at.success]
+        at = at.tabs[1].button(key="refresh-tasks").click().run()
+
+        # update focus session
+        at = at.date_input(key="fs_end_date_1_1").set_value(date(2024, 1, 4)).run()
+        at = at.time_input(key="fs_end_time_1_1").set_value(dtime(10, 30)).run()
+        at = at.checkbox(key="fs_comp_1_1").check().run()
+        at = at.button(key="FormSubmitter:fs-edit-1-1-Update").click().run()
+        assert "Updated" in [s.value for s in at.success]
+        at = at.tabs[1].button(key="refresh-tasks").click().run()
+
+        # delete focus session
+        at = at.button(key="fsdel_1_1").click().run()
+        assert "Deleted" in [s.value for s in at.success]
+        at = at.tabs[1].button(key="refresh-tasks").click().run()
+
         # calendar views
         at = at.tabs[2].date_input(key="calendar-date").set_value(date(2024, 1, 1)).run()
         at = at.tabs[2].selectbox[0].set_value("Day").run()


### PR DESCRIPTION
## Summary
- implement focus session tracking for tasks
- expose focus session REST endpoints
- add focus session controls to GUI
- document new feature in README
- add tests for API and GUI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821852ee648327a4e4852cc7389787