### PR TITLE
Add task priority support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This project provides a simple calendar application with a REST API and a Streamlit GUI. Users can create, update, delete, and list appointments.
 It also supports managing tasks with optional subtasks. Subtasks are useful for breaking large tasks into smaller steps, which can be helpful for users with ADHD.
 Additionally, tasks now support **focus sessions** to encourage short, timed work intervals. This feature is designed with ADHD users in mind to aid concentration.
+Tasks also have a **priority** level from 1-5 to help ADHD users identify what to focus on first.
 
 ## Requirements
 
@@ -57,6 +58,11 @@ Subtasks are managed via the following endpoints:
 - `GET /tasks/{task_id}/subtasks` – list subtasks of a task
 - `PUT /tasks/{task_id}/subtasks/{subtask_id}` – update a subtask
 - `DELETE /tasks/{task_id}/subtasks/{subtask_id}` – delete a subtask
+
+## Task Priority
+
+Each task has a `priority` from 1 (lowest) to 5 (highest). Use this field when
+creating or updating tasks to highlight important items.
 
 ## Focus Session API
 

--- a/app/models.py
+++ b/app/models.py
@@ -44,6 +44,7 @@ class Task(Base):
     end_time = Column(Time, nullable=True)
     perceived_difficulty = Column(Integer, nullable=True)
     estimated_difficulty = Column(Integer, nullable=True)
+    priority = Column(Integer, nullable=False, default=3)
     worked_on = Column(Boolean, default=False)
     paused = Column(Boolean, default=False)
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -45,6 +45,7 @@ class TaskBase(BaseModel):
     end_time: time | None = None
     perceived_difficulty: int | None = None
     estimated_difficulty: int | None = None
+    priority: int = 3
     worked_on: bool = False
     paused: bool = False
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -171,6 +171,7 @@ with tabs[1]:
         end_time = st.time_input("End Time", key="task-end-time")
         perceived = st.number_input("Perceived Difficulty", value=0, step=1, key="task-perceived")
         estimated = st.number_input("Estimated Difficulty", value=0, step=1, key="task-estimated")
+        priority = st.number_input("Priority", value=3, min_value=1, max_value=5, step=1, key="task-priority")
         worked_on = st.checkbox("Worked On", value=False, key="task-worked")
         paused = st.checkbox("Paused", value=False, key="task-paused")
         submitted = st.form_submit_button("Create")
@@ -185,6 +186,7 @@ with tabs[1]:
                 "end_time": end_time.isoformat(),
                 "perceived_difficulty": int(perceived),
                 "estimated_difficulty": int(estimated),
+                "priority": int(priority),
                 "worked_on": worked_on,
                 "paused": paused,
             }
@@ -198,7 +200,7 @@ with tabs[1]:
     st.header("Tasks")
     for task in st.session_state["tasks"]:
         with st.expander(task["title"]):
-            st.write(f"Due: {task['due_date']}")
+            st.write(f"Due: {task['due_date']} | Priority: {task.get('priority', 3)}")
             with st.form(f'task-edit-{task["id"]}'):
                 title = st.text_input("Title", value=task["title"], key=f'task_title_{task["id"]}')
                 description = st.text_input("Description", value=task.get("description", ""), key=f'task_description_{task["id"]}')
@@ -209,6 +211,7 @@ with tabs[1]:
                 etime = st.time_input("End Time", value=dtime.fromisoformat(task.get("end_time", "00:00:00")), key=f'etime_{task["id"]}')
                 pdiff = st.number_input("Perceived Difficulty", value=task.get("perceived_difficulty", 0) or 0, key=f'pdiff_{task["id"]}', step=1)
                 ediff = st.number_input("Estimated Difficulty", value=task.get("estimated_difficulty", 0) or 0, key=f'ediff_{task["id"]}', step=1)
+                prio = st.number_input("Priority", value=task.get("priority", 3) or 3, min_value=1, max_value=5, step=1, key=f'prio_{task["id"]}')
                 wo = st.checkbox("Worked On", value=task.get("worked_on", False), key=f'wo_{task["id"]}')
                 pa = st.checkbox("Paused", value=task.get("paused", False), key=f'pa_{task["id"]}')
                 if st.form_submit_button("Update"):
@@ -222,6 +225,7 @@ with tabs[1]:
                         "end_time": etime.isoformat(),
                         "perceived_difficulty": int(pdiff),
                         "estimated_difficulty": int(ediff),
+                        "priority": int(prio),
                         "worked_on": wo,
                         "paused": pa,
                     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,6 +79,7 @@ def test_task_crud():
         "end_time": "10:00:00",
         "perceived_difficulty": 2,
         "estimated_difficulty": 3,
+        "priority": 3,
         "worked_on": False,
         "paused": False,
     }
@@ -86,6 +87,7 @@ def test_task_crud():
     assert r.status_code == 200
     task = r.json()
     assert task["title"] == data["title"]
+    assert task["priority"] == data["priority"]
 
     r = requests.get(f"{API_URL}/tasks")
     assert r.status_code == 200
@@ -93,9 +95,11 @@ def test_task_crud():
 
     update = data.copy()
     update["title"] = "Updated Task"
+    update["priority"] = 4
     r = requests.put(f"{API_URL}/tasks/{task['id']}", json=update)
     assert r.status_code == 200
     assert r.json()["title"] == "Updated Task"
+    assert r.json()["priority"] == 4
 
     r = requests.delete(f"{API_URL}/tasks/{task['id']}")
     assert r.status_code == 200
@@ -115,12 +119,14 @@ def test_subtask_crud():
         "end_time": "10:00:00",
         "perceived_difficulty": 2,
         "estimated_difficulty": 3,
+        "priority": 3,
         "worked_on": False,
         "paused": False,
     }
     r = requests.post(f"{API_URL}/tasks", json=task_data)
     assert r.status_code == 200
     task = r.json()
+    assert task["priority"] == 3
 
     sub_data = {"title": "Subtask 1", "completed": False}
     r = requests.post(f"{API_URL}/tasks/{task['id']}/subtasks", json=sub_data)
@@ -157,6 +163,7 @@ def test_focus_session_crud():
         "end_time": "10:00:00",
         "perceived_difficulty": 2,
         "estimated_difficulty": 3,
+        "priority": 3,
         "worked_on": False,
         "paused": False,
     }

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -62,6 +62,7 @@ def test_full_gui_interaction():
         at = at.tabs[1].time_input(key="task-end-time").set_value(dtime(10, 0)).run()
         at = at.tabs[1].number_input(key="task-perceived").set_value(2).run()
         at = at.tabs[1].number_input(key="task-estimated").set_value(3).run()
+        at = at.tabs[1].number_input(key="task-priority").set_value(3).run()
         at = at.tabs[1].button[1].click().run()
         assert "Created" in [s.value for s in at.success]
         at = at.tabs[1].button(key="refresh-tasks").click().run()
@@ -141,6 +142,7 @@ def test_full_gui_interaction():
         at = at.time_input(key="etime_1").set_value(dtime(11, 0)).run()
         at = at.number_input(key="pdiff_1").set_value(3).run()
         at = at.number_input(key="ediff_1").set_value(4).run()
+        at = at.number_input(key="prio_1").set_value(4).run()
         at = at.checkbox(key="wo_1").check().run()
         at = at.tabs[1].button[2].click().run()
         assert "Updated" in [s.value for s in at.success]


### PR DESCRIPTION
## Summary
- add new `priority` field to `Task` model and schema
- support priority in Streamlit UI for creating and editing tasks
- describe task priority in README
- extend API and GUI tests for the new priority field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821b9ee3fc8327872d53145aabae62