### PR TITLE
Add automated task planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,11 @@ Focus sessions help break work into manageable chunks. Endpoints:
 - `GET /tasks/{task_id}/focus_sessions` – list focus sessions for a task
 - `PUT /tasks/{task_id}/focus_sessions/{session_id}` – update a focus session
 - `DELETE /tasks/{task_id}/focus_sessions/{session_id}` – delete a focus session
+
+## Automatic Task Planning
+
+Create and schedule tasks in one step with `POST /tasks/plan`.
+Send JSON with `title`, `description`, `estimated_difficulty`,
+`estimated_duration_minutes` and `due_date`.
+The service splits the work into 25-minute focus sessions with
+Pomodoro-style breaks and ensures no overlap with existing calendar entries.

--- a/app/models.py
+++ b/app/models.py
@@ -44,6 +44,7 @@ class Task(Base):
     end_time = Column(Time, nullable=True)
     perceived_difficulty = Column(Integer, nullable=True)
     estimated_difficulty = Column(Integer, nullable=True)
+    estimated_duration_minutes = Column(Integer, nullable=True)
     priority = Column(Integer, nullable=False, default=3)
     worked_on = Column(Boolean, default=False)
     paused = Column(Boolean, default=False)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -45,6 +45,7 @@ class TaskBase(BaseModel):
     end_time: time | None = None
     perceived_difficulty: int | None = None
     estimated_difficulty: int | None = None
+    estimated_duration_minutes: int | None = None
     priority: int = 3
     worked_on: bool = False
     paused: bool = False
@@ -52,6 +53,14 @@ class TaskBase(BaseModel):
 
 class TaskCreate(TaskBase):
     pass
+
+
+class PlanTaskCreate(BaseModel):
+    title: str
+    description: str | None = None
+    estimated_difficulty: int
+    estimated_duration_minutes: int
+    due_date: date
 
 
 class TaskUpdate(TaskBase):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -160,6 +160,28 @@ with tabs[1]:
     if st.button("Refresh Tasks", key="refresh-tasks"):
         refresh_tasks()
 
+    st.subheader("Plan Task Automatically")
+    with st.form("plan-form"):
+        p_title = st.text_input("Title", key="plan-title")
+        p_desc = st.text_input("Description", key="plan-desc")
+        p_diff = st.number_input("Estimated Difficulty", min_value=1, max_value=5, step=1, key="plan-diff")
+        p_duration = st.number_input("Estimated Duration Minutes", min_value=1, step=1, key="plan-dur")
+        p_due = st.date_input("Due Date", key="plan-due")
+        if st.form_submit_button("Plan"):
+            data = {
+                "title": p_title,
+                "description": p_desc,
+                "estimated_difficulty": int(p_diff),
+                "estimated_duration_minutes": int(p_duration),
+                "due_date": p_due.isoformat(),
+            }
+            r = requests.post(f"{API_URL}/tasks/plan", json=data)
+            if r.status_code == 200:
+                st.success("Planned")
+                refresh_tasks()
+            else:
+                st.error("Error planning task")
+
     st.header("Create Task")
     with st.form("task-create-form"):
         t_title = st.text_input("Title", key="task-title")


### PR DESCRIPTION
## Summary
- introduce a TaskPlanner service with automatic scheduling
- add `/tasks/plan` endpoint
- support `estimated_duration_minutes` in Task model and schema
- extend Streamlit GUI with planning form
- document new feature in README
- update tests for dynamic dates and new planner

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821fdff21483279f30fd7310c78abd