### PR TITLE
Add automatic task splitting and calendar session display

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ Send JSON with `title`, `description`, `estimated_difficulty`,
 `estimated_duration_minutes` and `due_date`.
 The service splits the work into 25-minute focus sessions with
 Pomodoro-style breaks and ensures no overlap with existing calendar entries.
+Each focus session also creates a corresponding subtask so large tasks are
+automatically broken into manageable parts.

--- a/app/main.py
+++ b/app/main.py
@@ -169,9 +169,20 @@ class TaskPlanner:
         events = self._collect_events()
         sessions = self._schedule_sessions(data.estimated_duration_minutes, data.due_date, events)
 
-        for s, e in sessions:
-            fs = models.FocusSession(task_id=task.id, start_time=s, end_time=e, completed=False)
+        for idx, (s, e) in enumerate(sessions, start=1):
+            fs = models.FocusSession(
+                task_id=task.id,
+                start_time=s,
+                end_time=e,
+                completed=False,
+            )
             self.db.add(fs)
+            sub = models.Subtask(
+                task_id=task.id,
+                title=f"Part {idx}",
+                completed=False,
+            )
+            self.db.add(sub)
         if sessions:
             task.start_date = sessions[0][0].date()
             task.start_time = sessions[0][0].time()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -222,42 +222,50 @@ with tabs[1]:
     st.header("Tasks")
     for task in st.session_state["tasks"]:
         with st.expander(task["title"]):
-            st.write(f"Due: {task['due_date']} | Priority: {task.get('priority', 3)}")
-            with st.form(f'task-edit-{task["id"]}'):
-                title = st.text_input("Title", value=task["title"], key=f'task_title_{task["id"]}')
-                description = st.text_input("Description", value=task.get("description", ""), key=f'task_description_{task["id"]}')
-                due = st.date_input("Due Date", value=date.fromisoformat(task["due_date"]), key=f'due_{task["id"]}')
-                sdate = st.date_input("Start Date", value=date.fromisoformat(task.get("start_date", task["due_date"])), key=f'sdate_{task["id"]}')
-                stime = st.time_input("Start Time", value=dtime.fromisoformat(task.get("start_time", "00:00:00")), key=f'stime_{task["id"]}')
-                edate = st.date_input("End Date", value=date.fromisoformat(task.get("end_date", task["due_date"])), key=f'edate_{task["id"]}')
-                etime = st.time_input("End Time", value=dtime.fromisoformat(task.get("end_time", "00:00:00")), key=f'etime_{task["id"]}')
-                pdiff = st.number_input("Perceived Difficulty", value=task.get("perceived_difficulty", 0) or 0, key=f'pdiff_{task["id"]}', step=1)
-                ediff = st.number_input("Estimated Difficulty", value=task.get("estimated_difficulty", 0) or 0, key=f'ediff_{task["id"]}', step=1)
-                prio = st.number_input("Priority", value=task.get("priority", 3) or 3, min_value=1, max_value=5, step=1, key=f'prio_{task["id"]}')
-                wo = st.checkbox("Worked On", value=task.get("worked_on", False), key=f'wo_{task["id"]}')
-                pa = st.checkbox("Paused", value=task.get("paused", False), key=f'pa_{task["id"]}')
-                if st.form_submit_button("Update"):
-                    data = {
-                        "title": title,
-                        "description": description,
-                        "due_date": due.isoformat(),
-                        "start_date": sdate.isoformat(),
-                        "end_date": edate.isoformat(),
-                        "start_time": stime.isoformat(),
-                        "end_time": etime.isoformat(),
-                        "perceived_difficulty": int(pdiff),
-                        "estimated_difficulty": int(ediff),
-                        "priority": int(prio),
-                        "worked_on": wo,
-                        "paused": pa,
-                    }
-                    resp = requests.put(f"{API_URL}/tasks/{task['id']}", json=data)
-                    if resp.status_code == 200:
-                        st.success("Updated")
-                        refresh_tasks()
-                    else:
-                        st.error("Error updating task")
-            with st.expander("Subtasks"):
+            st.write(
+                f"Due: {task['due_date']} | Priority: {task.get('priority', 3)}"
+            )
+
+            edit_tab, sub_tab, fs_tab = st.tabs(["Edit", "Subtasks", "Focus Sessions"])
+
+            with edit_tab:
+                with st.form(f'task-edit-{task["id"]}'):
+                    title = st.text_input("Title", value=task["title"], key=f'task_title_{task["id"]}')
+                    description = st.text_input("Description", value=task.get("description", ""), key=f'task_description_{task["id"]}')
+                    due = st.date_input("Due Date", value=date.fromisoformat(task["due_date"]), key=f'due_{task["id"]}')
+                    sdate = st.date_input("Start Date", value=date.fromisoformat(task.get("start_date", task["due_date"])), key=f'sdate_{task["id"]}')
+                    stime = st.time_input("Start Time", value=dtime.fromisoformat(task.get("start_time", "00:00:00")), key=f'stime_{task["id"]}')
+                    edate = st.date_input("End Date", value=date.fromisoformat(task.get("end_date", task["due_date"])), key=f'edate_{task["id"]}')
+                    etime = st.time_input("End Time", value=dtime.fromisoformat(task.get("end_time", "00:00:00")), key=f'etime_{task["id"]}')
+                    pdiff = st.number_input("Perceived Difficulty", value=task.get("perceived_difficulty", 0) or 0, key=f'pdiff_{task["id"]}', step=1)
+                    ediff = st.number_input("Estimated Difficulty", value=task.get("estimated_difficulty", 0) or 0, key=f'ediff_{task["id"]}', step=1)
+                    prio = st.number_input("Priority", value=task.get("priority", 3) or 3, min_value=1, max_value=5, step=1, key=f'prio_{task["id"]}')
+                    wo = st.checkbox("Worked On", value=task.get("worked_on", False), key=f'wo_{task["id"]}')
+                    pa = st.checkbox("Paused", value=task.get("paused", False), key=f'pa_{task["id"]}')
+                    if st.form_submit_button("Update"):
+                        data = {
+                            "title": title,
+                            "description": description,
+                            "due_date": due.isoformat(),
+                            "start_date": sdate.isoformat(),
+                            "end_date": edate.isoformat(),
+                            "start_time": stime.isoformat(),
+                            "end_time": etime.isoformat(),
+                            "perceived_difficulty": int(pdiff),
+                            "estimated_difficulty": int(ediff),
+                            "priority": int(prio),
+                            "worked_on": wo,
+                            "paused": pa,
+                        }
+                        resp = requests.put(
+                            f"{API_URL}/tasks/{task['id']}", json=data
+                        )
+                        if resp.status_code == 200:
+                            st.success("Updated")
+                            refresh_tasks()
+                        else:
+                            st.error("Error updating task")
+            with sub_tab:
                 for sub in task.get("subtasks", []):
                     with st.form(f'subtask-edit-{task["id"]}-{sub["id"]}'):
                         stitle = st.text_input("Title", value=sub["title"], key=f'subtitle_{task["id"]}_{sub["id"]}')
@@ -287,7 +295,8 @@ with tabs[1]:
                             refresh_tasks()
                         else:
                             st.error("Error creating subtask")
-            with st.expander("Focus Sessions"):
+
+            with fs_tab:
                 for fs in task.get("focus_sessions", []):
                     with st.form(f'fs-edit-{task["id"]}-{fs["id"]}'):
                         end_dt = datetime.fromisoformat(fs["end_time"])
@@ -442,6 +451,16 @@ with tabs[2]:
                 "end": edt.isoformat(),
             }
         )
+        for fs in task.get("focus_sessions", []):
+            events.append(
+                {
+                    "id": f"fs{fs['id']}",
+                    "title": f"Focus: {task['title']}",
+                    "start": fs["start_time"],
+                    "end": fs["end_time"],
+                    "color": "#888888",
+                }
+            )
 
     options = {
         "initialDate": st.session_state["calendar_date"].isoformat(),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,6 +24,8 @@ TOMORROW = TODAY + timedelta(days=1)
 
 @pytest.fixture(autouse=True)
 def start_server():
+    if os.path.exists("appointments.db"):
+        os.remove("appointments.db")
     proc = subprocess.Popen([sys.executable, "-m", "uvicorn", "app.main:app"])
     assert wait_for_api(f"{API_URL}/appointments")
     yield
@@ -227,6 +229,8 @@ def test_plan_task():
     task = r.json()
     fs = requests.get(f"{API_URL}/tasks/{task['id']}/focus_sessions").json()
     assert len(fs) == 2
+    subs = requests.get(f"{API_URL}/tasks/{task['id']}/subtasks").json()
+    assert len(subs) == len(fs)
     for s in fs:
         s_start = datetime.fromisoformat(s["start_time"])
         s_end = datetime.fromisoformat(s["end_time"])

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -106,34 +106,49 @@ def test_full_gui_interaction():
         assert "Deleted" in [s.value for s in at.success]
         at = at.tabs[1].button(key="refresh-tasks").click().run()
 
-        # calendar views
-        at = at.tabs[2].date_input(key="calendar-date").set_value(TODAY).run()
-        at = at.tabs[2].selectbox[0].set_value("Day").run()
-        assert TODAY.isoformat() in at.tabs[2].markdown[0].value
-        assert any("Meeting" in md.value for md in at.tabs[2].markdown)
-        at = at.tabs[2].button[1].click().run()
-        assert (TODAY + timedelta(days=1)).isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[0].click().run()
-        assert TODAY.isoformat() in at.tabs[2].markdown[0].value
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        at = cal_tab.date_input(key="calendar-date").set_value(TODAY).run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        at = cal_tab.selectbox[0].set_value("Day").run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
+        assert any("Meeting" in md.value for md in cal_tab.markdown)
+        at = cal_tab.button(key="cal-next").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert (TODAY + timedelta(days=1)).isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-prev").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
 
-        at = at.tabs[2].selectbox[0].set_value("Week").run()
-        assert TODAY.isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[1].click().run()
-        assert (TODAY + timedelta(days=7)).isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[0].click().run()
+        at = cal_tab.selectbox[0].set_value("Week").run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-next").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert (TODAY + timedelta(days=7)).isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-prev").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
 
-        at = at.tabs[2].selectbox[0].set_value("Two Weeks").run()
-        assert TODAY.isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[1].click().run()
-        assert (TODAY + timedelta(days=14)).isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[0].click().run()
+        at = cal_tab.selectbox[0].set_value("Two Weeks").run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-next").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert (TODAY + timedelta(days=14)).isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-prev").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
 
-        at = at.tabs[2].selectbox[0].set_value("Month").run()
-        assert TODAY.isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[1].click().run()
-        assert (TODAY + timedelta(days=31)).isoformat() in at.tabs[2].markdown[0].value
-        at = at.tabs[2].button[0].click().run()
-
+        at = cal_tab.selectbox[0].set_value("Month").run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-next").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert (TODAY + timedelta(days=31)).isoformat() in cal_tab.markdown[0].value
+        at = cal_tab.button(key="cal-prev").click().run()
+        cal_tab = next(t for t in at.tabs if t.label == "Calendar")
+        assert TODAY.isoformat() in cal_tab.markdown[0].value
         # update appointment
         at = at.text_input(key="title_1").set_value("Updated Meeting").run()
         at = at.text_input(key="desc_1").set_value("Updated notes").run()


### PR DESCRIPTION
## Summary
- extend `TaskPlanner.plan` to generate subtasks and schedule focus sessions
- show subtasks and sessions in the task tab with new tabs
- render focus sessions on the calendar
- document automatic planning in README
- adjust tests for new functionality and dynamic calendar tab handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882235e74c08327b791bf2ea5e2d51a