### PR TITLE
Improve planner with lunch break

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,14 @@ and workload distribution. Additional settings allow advanced tuning:
   is inserted (default 4)
 - ``WORK_DAYS`` – comma-separated list of weekday numbers (0=Monday) that are
   considered working days. By default all days are allowed.
+- ``LUNCH_START_HOUR`` – hour when a daily lunch break begins (default 12)
+- ``LUNCH_DURATION_MINUTES`` – length of the lunch break (default 60)
 
 More difficult or high priority tasks are placed earlier in the day while
 easier ones are scheduled later, spreading sessions across days when needed for
 smarter and more personalised planning. Session times also consider urgency
 based on how soon a task is due and the planner balances the number of focus
 sessions per day so that work is spread evenly until the deadline.
+The lunch break settings ensure planning pauses between ``LUNCH_START_HOUR``
+and ``LUNCH_START_HOUR`` plus ``LUNCH_DURATION_MINUTES`` so focus sessions never
+overlap with this daily break.


### PR DESCRIPTION
## Summary
- add environment variables for a lunch break
- skip scheduling focus sessions during the lunch break
- document the new settings in the README
- test that the planner avoids lunch time

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68824f3b39dc8327960835baa9c9c47c