### PR TITLE
Improve task planner with daily session limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ and workload distribution. Additional settings allow advanced tuning:
 - ``LONG_BREAK_MINUTES`` – long break length (default 15)
 - ``SESSIONS_BEFORE_LONG_BREAK`` – number of sessions before a long break
   is inserted (default 4)
+- ``MAX_SESSIONS_PER_DAY`` – maximum sessions per task each day (default 4)
+- ``DAILY_SESSION_LIMIT`` – maximum sessions from all tasks on a single day
+  (default unlimited)
 - ``WORK_DAYS`` – comma-separated list of weekday numbers (0=Monday) that are
   considered working days. By default all days are allowed.
 - ``LUNCH_START_HOUR`` – hour when a daily lunch break begins (default 12)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -592,3 +592,23 @@ def test_planner_prefers_high_energy(monkeypatch):
         start = datetime.fromisoformat(s["start_time"])
         assert 8 <= start.hour < 11
 
+
+@pytest.mark.env(DAILY_SESSION_LIMIT="1")
+def test_planner_daily_session_limit(monkeypatch):
+    due = TODAY + timedelta(days=2)
+    data = {
+        "title": "Limited",
+        "description": "",
+        "estimated_difficulty": 2,
+        "estimated_duration_minutes": 50,
+        "due_date": due.isoformat(),
+        "priority": 3,
+    }
+    r = requests.post(f"{API_URL}/tasks/plan", json=data)
+    assert r.status_code == 200
+    task = r.json()
+    sessions = requests.get(f"{API_URL}/tasks/{task['id']}/focus_sessions").json()
+    assert len(sessions) == 2
+    days = [datetime.fromisoformat(s["start_time"]).date() for s in sessions]
+    assert len(set(days)) == 2
+


### PR DESCRIPTION
## Summary
- extend TaskPlanner with `_session_counts` and daily session limit
- respect new `DAILY_SESSION_LIMIT` env var when scheduling
- document new variable in README
- test daily session limit enforcement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68825bb71614832791b6c1a00341b75d