### PR TITLE
Improve task planner energy matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,4 @@ and ``LUNCH_START_HOUR`` plus ``LUNCH_DURATION_MINUTES`` so focus sessions never
 overlap with this daily break.
 Hard tasks are also moved out of the ``LOW_ENERGY_START_HOUR`` to ``LOW_ENERGY_END_HOUR`` window to keep sessions productive.
 Important tasks are additionally pulled into the ``HIGH_ENERGY_START_HOUR`` to ``HIGH_ENERGY_END_HOUR`` window whenever possible so the most challenging work occurs during peak focus times.
+Providing an ``ENERGY_CURVE`` lets the planner map task importance to these energy levels so that highly important tasks start at times with higher energy values while less critical ones are placed into lower energy periods.

--- a/app/main.py
+++ b/app/main.py
@@ -192,11 +192,6 @@ class TaskPlanner:
                 except ValueError:
                     energy_curve = None
 
-        if energy_curve and len(energy_curve) == 24:
-            hours = range(start_hour, end_hour)
-            best = max(hours, key=lambda h: energy_curve[h])
-            return best
-
         diff_w = float(os.getenv("DIFFICULTY_WEIGHT", "1"))
         prio_w = float(os.getenv("PRIORITY_WEIGHT", "1"))
         urg_w = float(os.getenv("URGENCY_WEIGHT", "1"))
@@ -205,6 +200,14 @@ class TaskPlanner:
         weight = (
             difficulty * diff_w + priority * prio_w + urgency * urg_w
         ) / total_w
+
+        if energy_curve and len(energy_curve) == 24:
+            hours = range(start_hour, end_hour)
+            importance = weight
+            target = (importance / 5) * max(energy_curve[h] for h in hours)
+            best = min(hours, key=lambda h: (energy_curve[h] - target) ** 2)
+            return best
+
         offset = max(0, round(5 - weight))
         return min(end_hour - 1, start_hour + offset)
     def _avoid_low_energy(self, dt: datetime, difficulty: int) -> datetime:


### PR DESCRIPTION
## Summary
- refine `_preferred_start_hour` to use energy curves with task importance
- document energy curve importance mapping
- test that important tasks use high energy periods

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882a56d78d883279ff4fd4562560482