### PR TITLE
Add energy-aware day ordering to task planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ a corresponding subtask so large tasks are automatically broken into manageable
 parts.
 The planner honours the ``WORK_START_HOUR`` and ``WORK_END_HOUR`` environment
 variables as well as ``MAX_SESSIONS_PER_DAY`` to adapt to custom working hours
-and workload distribution. Additional settings allow advanced tuning:
+and workload distribution. When ``INTELLIGENT_DAY_ORDER`` is enabled it
+also weighs the available energy on each day using ``ENERGY_DAY_ORDER_WEIGHT``
+so that sessions land on days with both enough time and high energy. Additional
+settings allow advanced tuning:
 
 - ``SESSION_LENGTH_MINUTES`` – duration of each focus session (default 25)
 - ``INTELLIGENT_SESSION_LENGTH`` – scale session length based on difficulty and priority when set to ``1`` or ``true`` (default disabled)
@@ -106,6 +109,8 @@ and workload distribution. Additional settings allow advanced tuning:
   (default unlimited)
 - ``INTELLIGENT_DAY_ORDER`` – prefer days with more free time when scheduling
   focus sessions (default disabled)
+- ``ENERGY_DAY_ORDER_WEIGHT`` – additional weight for days with higher available
+  energy when intelligent day order is enabled (default 0)
 - ``WORK_DAYS`` – comma-separated list of weekday numbers (0=Monday) that are
   considered working days. By default all days are allowed.
 - ``LUNCH_START_HOUR`` – hour when a daily lunch break begins (default 12)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -66,6 +66,7 @@ class PlanTaskCreate(BaseModel):
     high_energy_end_hour: int | None = None
     fatigue_break_factor: float | None = None
     energy_curve: list[int] | None = None
+    energy_day_order_weight: float | None = None
 
 
 class TaskUpdate(TaskBase):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -197,6 +197,13 @@ with tabs[1]:
             value=os.getenv("ENERGY_CURVE", ""),
             key="plan-curve",
         )
+        p_day_weight = st.number_input(
+            "Energy Day Order Weight",
+            min_value=0.0,
+            value=float(os.getenv("ENERGY_DAY_ORDER_WEIGHT", "0")),
+            step=0.1,
+            key="plan-day-weight",
+        )
         if st.form_submit_button("Plan"):
             data = {
                 "title": p_title,
@@ -209,6 +216,7 @@ with tabs[1]:
                 "high_energy_end_hour": int(he_end),
                 "fatigue_break_factor": float(p_fatigue),
                 "energy_curve": [int(x) for x in p_curve.split(",") if x.strip()],
+                "energy_day_order_weight": float(p_day_weight),
             }
             r = requests.post(f"{API_URL}/tasks/plan", json=data)
             if r.status_code == 200:


### PR DESCRIPTION
## Summary
- implement `_available_energy` and upgrade day selection to account for energy levels
- extend `_schedule_sessions` and planning API to use the energy weight
- expose new weight input in Streamlit UI
- document `ENERGY_DAY_ORDER_WEIGHT` and new planning behaviour
- add test for energy-weighted day ordering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68833c8652b483279853aa3a0a8917bb