### PR TITLE
Enhance automated task planning with deep work mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ settings allow advanced tuning:
   highest energy level (default disabled)
 - ``SLOT_STEP_MINUTES`` – minutes between candidate start times when intelligent
   slot selection is enabled (default 15)
+- ``DEEP_WORK_THRESHOLD`` – difficulty level from 1-5 that triggers scheduling
+  all focus sessions for that task consecutively in the largest available block
+  (default 0 disables deep work planning)
 
 More difficult or high priority tasks are placed earlier in the day while
 easier ones are scheduled later, spreading sessions across days when needed for


### PR DESCRIPTION
## Summary
- add helpers to compute free time blocks and largest free interval
- implement `DEEP_WORK_THRESHOLD` to schedule difficult tasks in a single uninterrupted block
- document new environment variable
- test deep work scheduling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68833eb075848327977ee2554ffe4fb0