### PR TITLE
Add category productivity weighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ settings allow advanced tuning:
 - ``CATEGORY_DAY_WEIGHT`` – additional weight favouring days that already contain events of the same category (default 0)
 - ``PRODUCTIVITY_HISTORY_WEIGHT`` – weight of past session completion rates per hour when choosing slots (default 0)
 - ``PRODUCTIVITY_HALF_LIFE_DAYS`` – days until historical weights halve when calculating productivity (default 30)
+- ``CATEGORY_PRODUCTIVITY_WEIGHT`` – weight of category-specific completion rates when selecting slots (default 0)
 - ``SPACED_REPETITION_FACTOR`` – multiply the gap between consecutive sessions by this factor for spaced repetition (default 1 disables spacing)
 - ``preferred_start_hour`` and ``preferred_end_hour`` – optional fields on categories restricting scheduling to this window
 

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -80,6 +80,7 @@ class PlanTaskCreate(BaseModel):
     intelligent_transition_buffer: bool | None = None
     productivity_history_weight: float | None = None
     productivity_half_life_days: int | None = None
+    category_productivity_weight: float | None = None
     spaced_repetition_factor: float | None = None
 
 

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -232,6 +232,13 @@ with tabs[1]:
             step=0.1,
             key="plan-day-weight",
         )
+        p_cat_prod = st.number_input(
+            "Category Productivity Weight",
+            min_value=0.0,
+            value=float(os.getenv("CATEGORY_PRODUCTIVITY_WEIGHT", "0")),
+            step=0.1,
+            key="plan-cat-prod",
+        )
         p_buffer = st.number_input(
             "Transition Buffer Minutes",
             min_value=0,
@@ -267,6 +274,7 @@ with tabs[1]:
                 "energy_day_order_weight": float(p_day_weight),
                 "transition_buffer_minutes": int(p_buffer),
                 "intelligent_transition_buffer": bool(p_int_buffer),
+                "category_productivity_weight": float(p_cat_prod),
                 "spaced_repetition_factor": float(p_spaced),
                 "category_id": p_category_id,
             }


### PR DESCRIPTION
## Summary
- incorporate category-specific productivity history into slot selection
- expose `category_productivity_weight` via API and GUI
- document `CATEGORY_PRODUCTIVITY_WEIGHT` environment variable
- respect work days when planning after hours
- test category-aware productivity scheduling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c4448a7c83278ffa1db1d987ac44