### PR TITLE
Improve task planning intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,9 @@ settings allow advanced tuning:
 - ``PRODUCTIVITY_HALF_LIFE_DAYS`` – days until historical weights halve when calculating productivity (default 30)
 - ``CATEGORY_PRODUCTIVITY_WEIGHT`` – weight of category-specific completion rates when selecting slots (default 0)
 - ``SPACED_REPETITION_FACTOR`` – multiply the gap between consecutive sessions by this factor for spaced repetition (default 1 disables spacing)
+- ``SESSION_COUNT_WEIGHT`` – penalty per already scheduled session on a day when choosing planning days (default 0)
+- ``DIFFICULTY_LOAD_WEIGHT`` – penalty based on total difficulty already scheduled on a day (default 0)
+- ``ENERGY_LOAD_WEIGHT`` – penalty based on total energy load already scheduled on a day (default 0)
 - ``preferred_start_hour`` and ``preferred_end_hour`` – optional fields on categories restricting scheduling to this window
 - ``energy_curve`` – optional 24 comma values on categories weighting hours for
   category tasks

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -84,6 +84,9 @@ class PlanTaskCreate(BaseModel):
     productivity_half_life_days: int | None = None
     category_productivity_weight: float | None = None
     spaced_repetition_factor: float | None = None
+    session_count_weight: float | None = None
+    difficulty_load_weight: float | None = None
+    energy_load_weight: float | None = None
 
 
 class TaskUpdate(TaskBase):

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -239,6 +239,27 @@ with tabs[1]:
             step=0.1,
             key="plan-cat-prod",
         )
+        p_sess_weight = st.number_input(
+            "Session Count Weight",
+            min_value=0.0,
+            value=float(os.getenv("SESSION_COUNT_WEIGHT", "0")),
+            step=0.1,
+            key="plan-sess-weight",
+        )
+        p_diff_load_weight = st.number_input(
+            "Difficulty Load Weight",
+            min_value=0.0,
+            value=float(os.getenv("DIFFICULTY_LOAD_WEIGHT", "0")),
+            step=0.1,
+            key="plan-diff-load-weight",
+        )
+        p_energy_load_weight = st.number_input(
+            "Energy Load Weight",
+            min_value=0.0,
+            value=float(os.getenv("ENERGY_LOAD_WEIGHT", "0")),
+            step=0.1,
+            key="plan-energy-load-weight",
+        )
         p_buffer = st.number_input(
             "Transition Buffer Minutes",
             min_value=0,
@@ -273,11 +294,14 @@ with tabs[1]:
                 "energy_curve": [int(x) for x in p_curve.split(",") if x.strip()],
                 "energy_day_order_weight": float(p_day_weight),
                 "transition_buffer_minutes": int(p_buffer),
-                "intelligent_transition_buffer": bool(p_int_buffer),
-                "category_productivity_weight": float(p_cat_prod),
-                "spaced_repetition_factor": float(p_spaced),
-                "category_id": p_category_id,
-            }
+            "intelligent_transition_buffer": bool(p_int_buffer),
+            "category_productivity_weight": float(p_cat_prod),
+            "spaced_repetition_factor": float(p_spaced),
+            "session_count_weight": float(p_sess_weight),
+            "difficulty_load_weight": float(p_diff_load_weight),
+            "energy_load_weight": float(p_energy_load_weight),
+            "category_id": p_category_id,
+        }
             r = requests.post(f"{API_URL}/tasks/plan", json=data)
             if r.status_code == 200:
                 st.success("Planned")


### PR DESCRIPTION
## Summary
- add load weighting parameters to PlanTaskCreate
- balance day selection using existing session, difficulty, and energy loads
- expose new weights in Streamlit planner form
- document new environment variables in README
- test new scheduling behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883d58e46908327b7150a62da171d29