### PR TITLE
Fix planner weekend workday scheduling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1065,6 +1065,8 @@ class TaskPlanner:
             if earliest is not None:
                 start_candidate = min(start_candidate, earliest)
         start_day = max(now.date(), start_candidate)
+        if start_day > last_work_day:
+            start_day = last_work_day
         start_day = self._next_day_by_free_time(
             start_day,
             last_work_day,


### PR DESCRIPTION
## Summary
- avoid raising an error when today isn't a work day but due date falls on a weekend
- ensure `start_day` never exceeds `last_work_day`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688475d2a4ec83279b23033fc7a3e245