### PR TITLE
Add CLI and docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,13 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior.
+
+**Expected behavior**
+What you expected to happen.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,7 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+---
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+## Summary
+Describe the changes introduced in this PR.
+
+## Testing
+- `pytest`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,6 @@
+# Contributing
+
+1. Fork the repository and create feature branches.
+2. Install pre-commit hooks with `pre-commit install`.
+3. Run `pytest` to ensure all tests pass before opening a pull request.
+4. Follow Black formatting and isort import ordering.

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,9 @@
+# Troubleshooting FAQ
+
+**The API does not start**
+
+Ensure all dependencies are installed. Run `pip install -r requirements.txt`.
+
+**The CLI cannot connect**
+
+Verify that the API is running and `API_URL` points to the correct address.

--- a/README.md
+++ b/README.md
@@ -198,3 +198,14 @@ Providing an ``ENERGY_CURVE`` lets the planner map task importance to these ener
 Enabling ``INTELLIGENT_SLOT_SELECTION`` further refines placement by scanning
 all free slots on a day and picking the time with the highest energy value so
 work always happens when focus is expected to be strongest.
+
+## Command Line Interface
+Use `python cli.py add` and `python cli.py list` to manage tasks from the terminal. Configure the API URL in `config.yaml` or via `API_URL` environment variable.
+
+
+## Docker Compose
+An example `docker-compose.yml` is provided to run the API in a container.
+
+
+See [USER_GUIDE.md](USER_GUIDE.md) for usage instructions and [FAQ.md](FAQ.md) for troubleshooting.
+

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,11 @@
+# Release Notes
+
+## v1.0.0
+
+Initial release with REST API, Streamlit GUI and task planner.
+
+## v1.1.0
+
+- Added command line interface for tasks.
+- Added Docker Compose setup.
+- Added YAML configuration support.

--- a/TODO.md
+++ b/TODO.md
@@ -36,7 +36,7 @@ The following steps aim to enhance the calendar and task planning application. E
 32. [ ] Integrate with Outlook Calendar API
 33. [ ] Add Slack notification integration
 34. [ ] Provide webhook support for custom integrations
-35. [ ] Add CLI tool for managing tasks
+35. [x] Add CLI tool for managing tasks
 36. [x] Document REST API with OpenAPI schema
 37. [ ] Generate API client from OpenAPI spec
 38. [ ] Add CI workflow for automated testing
@@ -46,7 +46,7 @@ The following steps aim to enhance the calendar and task planning application. E
 42. [x] Track code coverage with coverage.py
 43. [ ] Enforce 100% test coverage
 44. [x] Add static type checking with mypy
-45. [ ] Introduce dataclasses where appropriate
+45. [x] Introduce dataclasses where appropriate
 46. [ ] Refactor large functions into smaller units
 47. [ ] Add logging configuration options
 48. [ ] Create admin dashboard for system metrics
@@ -82,23 +82,23 @@ The following steps aim to enhance the calendar and task planning application. E
 78. [ ] Integrate time tracking for tasks
 79. [ ] Provide invoice generation for tracked time
 80. [ ] Allow partial task completion percentages
-81. [ ] Create user guide documentation
-82. [ ] Provide troubleshooting FAQ
+81. [x] Create user guide documentation
+82. [x] Provide troubleshooting FAQ
 83. [ ] Translate documentation into German
 84. [ ] Add screenshot walkthrough to README
-85. [ ] Provide example Docker Compose setup
-86. [ ] Add YAML configuration file support
-87. [ ] Allow environment variable overrides
+85. [x] Provide example Docker Compose setup
+86. [x] Add YAML configuration file support
+87. [x] Allow environment variable overrides
 88. [ ] Provide automated backup feature
 89. [ ] Support restoring from backup
 90. [ ] Add end-to-end Cypress tests for GUI
 91. [ ] Implement fuzz testing for API inputs
 92. [ ] Add security scanning to CI
-93. [ ] Integrate dependency updates with Dependabot
-94. [ ] Provide release notes for each version
+93. [x] Integrate dependency updates with Dependabot
+94. [x] Provide release notes for each version
 95. [ ] Add changelog management with towncrier
-96. [ ] Set up issue templates on GitHub
-97. [ ] Add pull request templates
-98. [ ] Provide contribution guidelines
+96. [x] Set up issue templates on GitHub
+97. [x] Add pull request templates
+98. [x] Provide contribution guidelines
 99. [ ] Run user surveys to gather feedback
 100. [ ] Plan marketing strategy for launch

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1,0 +1,28 @@
+# User Guide
+
+This guide explains how to operate the calendar and task planning application.
+
+## Starting the API
+
+Run `uvicorn app.main:app` to launch the REST API on `http://localhost:8000`.
+
+## Streamlit Interface
+
+Start the GUI with:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+The application opens in your browser and allows creating appointments and tasks.
+
+## Command Line Interface
+
+The `cli.py` script provides a minimal CLI for managing tasks. Example:
+
+```bash
+python cli.py add "Buy milk" --due-date 2025-01-01
+python cli.py list
+```
+
+The CLI reads `config.yaml` if present and honours the `API_URL` environment variable.

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+import yaml
+
+
+@dataclass
+class Settings:
+    """Application configuration loaded from YAML with environment overrides."""
+
+    api_url: str = "http://localhost:8000"
+
+
+class ConfigLoader:
+    """Load configuration from YAML and apply environment overrides."""
+
+    def __init__(self, path: str | None = None) -> None:
+        self.path = Path(path or os.getenv("CONFIG_FILE", "config.yaml"))
+
+    def load(self) -> Settings:
+        data: dict[str, str] = {}
+        if self.path.exists():
+            with self.path.open("r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                data.update({str(k): str(v) for k, v in loaded.items()})
+        if "API_URL" in os.environ:
+            data["api_url"] = os.environ["API_URL"]
+        return Settings(**{**Settings().__dict__, **data})

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Any
+
+import requests
+
+from app.config import ConfigLoader
+
+
+class BaseCLI:
+    """Base command line interface."""
+
+    def __init__(self) -> None:
+        self.parser = argparse.ArgumentParser(description="Task CLI")
+        self.subparsers = self.parser.add_subparsers(dest="command", required=True)
+        self.configure()
+
+    def configure(self) -> None:  # pragma: no cover - to be implemented in subclass
+        pass
+
+    def run(self, args: list[str] | None = None) -> None:
+        parsed = self.parser.parse_args(args=args)
+        handler = getattr(self, f"do_{parsed.command}")
+        handler(parsed)
+
+
+class TaskCLI(BaseCLI):
+    """CLI for managing tasks via the REST API."""
+
+    def __init__(self) -> None:
+        self.config = ConfigLoader().load()
+        super().__init__()
+
+    def configure(self) -> None:
+        add = self.subparsers.add_parser("add", help="Create a new task")
+        add.add_argument("title")
+        add.add_argument("--description", default="")
+        add.add_argument("--due-date", required=True)
+        add.add_argument("--priority", type=int, default=3)
+
+        self.subparsers.add_parser("list", help="List tasks")
+
+    def _api_url(self) -> str:
+        return self.config.api_url
+
+    def do_add(self, args: Any) -> None:
+        data = {
+            "title": args.title,
+            "description": args.description,
+            "due_date": args.due_date,
+            "priority": args.priority,
+        }
+        resp = requests.post(f"{self._api_url()}/tasks", json=data, timeout=5)
+        resp.raise_for_status()
+        task = resp.json()
+        print(f"Created task {task['id']}")
+
+    def do_list(self, args: Any) -> None:
+        resp = requests.get(f"{self._api_url()}/tasks", timeout=5)
+        resp.raise_for_status()
+        for task in resp.json():
+            print(f"{task['id']} {task['title']} (due {task['due_date']})")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    TaskCLI().run()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,1 @@
+api_url: http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  api:
+    image: python:3.12-slim
+    working_dir: /code
+    volumes:
+      - .:/code
+    command: bash -c "pip install -r requirements.txt && uvicorn app.main:app --host 0.0.0.0"
+    ports:
+      - "8000:8000"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+requests
+streamlit
+streamlit-calendar
+pyyaml

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,51 @@
+import os
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from cli import TaskCLI
+
+API_URL = "http://localhost:8000"
+TODAY = date.today().isoformat()
+
+
+def wait_for_api(url: str, timeout: float = 5.0):
+    import time
+    import requests
+
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            if requests.get(url).status_code == 200:
+                return True
+        except requests.exceptions.ConnectionError:
+            time.sleep(0.1)
+    return False
+
+
+@pytest.fixture
+def server():
+    if Path("appointments.db").exists():
+        Path("appointments.db").unlink()
+    proc = subprocess.Popen([sys.executable, "-m", "uvicorn", "app.main:app"])
+    assert wait_for_api(f"{API_URL}/appointments")
+    yield
+    proc.terminate()
+    proc.wait()
+    if Path("appointments.db").exists():
+        Path("appointments.db").unlink()
+
+
+def test_cli_add_and_list(server, capsys):
+    cli = TaskCLI()
+    cli.run(["add", "Test", "--due-date", TODAY])
+    captured = capsys.readouterr()
+    assert "Created task" in captured.out
+
+    cli.run(["list"])
+    captured = capsys.readouterr()
+    assert "Test" in captured.out


### PR DESCRIPTION
## Summary
- add minimal CLI for tasks using requests and ConfigLoader
- support YAML configuration with dataclass
- document new features in README, USER_GUIDE and FAQ
- add Docker Compose example and requirements
- provide issue and PR templates, contribution guide and release notes
- integrate Dependabot
- mark completed TODO items
- add tests for CLI

## Testing
- `pytest -q`
- `coverage run -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68847b01ec848327874ee47cefd0af4e