### PR TITLE
Implement logging config and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install coverage
+      - name: Run tests
+        run: |
+          coverage run -m pytest -q
+          coverage xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.coverage
+htmlcov/

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ uvicorn app.main:app
 The API will be available at `http://localhost:8000`.
 The API exposes an OpenAPI schema at `http://localhost:8000/openapi.json` and interactive docs at `http://localhost:8000/docs`.
 
+### Logging
+
+Set the log level with `LOG_LEVEL` in `config.yaml` or as an environment variable.
+
 ## Running the Streamlit GUI
 
 ```bash
@@ -201,6 +205,14 @@ work always happens when focus is expected to be strongest.
 
 ## Command Line Interface
 Use `python cli.py add` and `python cli.py list` to manage tasks from the terminal. Configure the API URL in `config.yaml` or via `API_URL` environment variable.
+
+## Generated API Client
+
+The `openapi_client` package is generated from the OpenAPI schema using `openapi-python-client`. Re-generate it with:
+
+```bash
+openapi-python-client generate --url http://localhost:8000/openapi.json --output-path openapi_client
+```
 
 
 ## Docker Compose

--- a/TODO.md
+++ b/TODO.md
@@ -38,8 +38,8 @@ The following steps aim to enhance the calendar and task planning application. E
 34. [ ] Provide webhook support for custom integrations
 35. [x] Add CLI tool for managing tasks
 36. [x] Document REST API with OpenAPI schema
-37. [ ] Generate API client from OpenAPI spec
-38. [ ] Add CI workflow for automated testing
+37. [x] Generate API client from OpenAPI spec
+38. [x] Add CI workflow for automated testing
 39. [x] Add pre-commit hooks for linting
 40. [x] Enforce formatting with Black
 41. [x] Enforce import order with isort
@@ -48,7 +48,7 @@ The following steps aim to enhance the calendar and task planning application. E
 44. [x] Add static type checking with mypy
 45. [x] Introduce dataclasses where appropriate
 46. [ ] Refactor large functions into smaller units
-47. [ ] Add logging configuration options
+47. [x] Add logging configuration options
 48. [ ] Create admin dashboard for system metrics
 49. [ ] Expose Prometheus metrics endpoint
 50. [ ] Add Grafana dashboards
@@ -102,3 +102,4 @@ The following steps aim to enhance the calendar and task planning application. E
 98. [x] Provide contribution guidelines
 99. [ ] Run user surveys to gather feedback
 100. [ ] Plan marketing strategy for launch
+47. [x] Add logging configuration options

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import logging
 import os
 from pathlib import Path
 
@@ -10,6 +11,15 @@ class Settings:
     """Application configuration loaded from YAML with environment overrides."""
 
     api_url: str = "http://localhost:8000"
+    log_level: str = "INFO"
+
+
+def setup_logging(level: str) -> None:
+    """Configure logging for the application."""
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
 
 
 class ConfigLoader:
@@ -27,4 +37,6 @@ class ConfigLoader:
                 data.update({str(k): str(v) for k, v in loaded.items()})
         if "API_URL" in os.environ:
             data["api_url"] = os.environ["API_URL"]
+        if "LOG_LEVEL" in os.environ:
+            data["log_level"] = os.environ["LOG_LEVEL"]
         return Settings(**{**Settings().__dict__, **data})

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import logging
 import math
 import os
 from datetime import date, datetime, time, timedelta
@@ -7,6 +8,10 @@ from sqlalchemy.orm import Session
 
 from . import models, schemas
 from .database import Base, SessionLocal, engine
+from .config import ConfigLoader, setup_logging
+
+settings = ConfigLoader().load()
+setup_logging(settings.log_level)
 
 Base.metadata.create_all(bind=engine)
 

--- a/cli.py
+++ b/cli.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import logging
 import os
 import sys
 from typing import Any
 
 import requests
 
-from app.config import ConfigLoader
+from app.config import ConfigLoader, setup_logging
 
 
 class BaseCLI:
@@ -32,6 +33,7 @@ class TaskCLI(BaseCLI):
 
     def __init__(self) -> None:
         self.config = ConfigLoader().load()
+        setup_logging(self.config.log_level)
         super().__init__()
 
     def configure(self) -> None:

--- a/openapi_client/.gitignore
+++ b/openapi_client/.gitignore
@@ -1,0 +1,23 @@
+__pycache__/
+build/
+dist/
+*.egg-info/
+.pytest_cache/
+
+# pyenv
+.python-version
+
+# Environments
+.env
+.venv
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# JetBrains
+.idea/
+
+/coverage.xml
+/.coverage

--- a/openapi_client/README.md
+++ b/openapi_client/README.md
@@ -1,0 +1,124 @@
+# fast-api-client
+A client library for accessing FastAPI
+
+## Usage
+First, create a client:
+
+```python
+from fast_api_client import Client
+
+client = Client(base_url="https://api.example.com")
+```
+
+If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
+
+```python
+from fast_api_client import AuthenticatedClient
+
+client = AuthenticatedClient(base_url="https://api.example.com", token="SuperSecretToken")
+```
+
+Now call your endpoint and use your models:
+
+```python
+from fast_api_client.models import MyDataModel
+from fast_api_client.api.my_tag import get_my_data_model
+from fast_api_client.types import Response
+
+with client as client:
+    my_data: MyDataModel = get_my_data_model.sync(client=client)
+    # or if you need more info (e.g. status_code)
+    response: Response[MyDataModel] = get_my_data_model.sync_detailed(client=client)
+```
+
+Or do the same thing with an async version:
+
+```python
+from fast_api_client.models import MyDataModel
+from fast_api_client.api.my_tag import get_my_data_model
+from fast_api_client.types import Response
+
+async with client as client:
+    my_data: MyDataModel = await get_my_data_model.asyncio(client=client)
+    response: Response[MyDataModel] = await get_my_data_model.asyncio_detailed(client=client)
+```
+
+By default, when you're calling an HTTPS API it will attempt to verify that SSL is working correctly. Using certificate verification is highly recommended most of the time, but sometimes you may need to authenticate to a server (especially an internal server) using a custom certificate bundle.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken",
+    verify_ssl="/path/to/certificate_bundle.pem",
+)
+```
+
+You can also disable certificate validation altogether, but beware that **this is a security risk**.
+
+```python
+client = AuthenticatedClient(
+    base_url="https://internal_api.example.com", 
+    token="SuperSecretToken", 
+    verify_ssl=False
+)
+```
+
+Things to know:
+1. Every path/method combo becomes a Python module with four functions:
+    1. `sync`: Blocking request that returns parsed data (if successful) or `None`
+    1. `sync_detailed`: Blocking request that always returns a `Request`, optionally with `parsed` set if the request was successful.
+    1. `asyncio`: Like `sync` but async instead of blocking
+    1. `asyncio_detailed`: Like `sync_detailed` but async instead of blocking
+
+1. All path/query params, and bodies become method arguments.
+1. If your endpoint had any tags on it, the first tag will be used as a module name for the function (my_tag above)
+1. Any endpoint which did not have a tag will be in `fast_api_client.api.default`
+
+## Advanced customizations
+
+There are more settings on the generated `Client` class which let you control more runtime behavior, check out the docstring on that class for more info. You can also customize the underlying `httpx.Client` or `httpx.AsyncClient` (depending on your use-case):
+
+```python
+from fast_api_client import Client
+
+def log_request(request):
+    print(f"Request event hook: {request.method} {request.url} - Waiting for response")
+
+def log_response(response):
+    request = response.request
+    print(f"Response event hook: {request.method} {request.url} - Status {response.status_code}")
+
+client = Client(
+    base_url="https://api.example.com",
+    httpx_args={"event_hooks": {"request": [log_request], "response": [log_response]}},
+)
+
+# Or get the underlying httpx client to modify directly with client.get_httpx_client() or client.get_async_httpx_client()
+```
+
+You can even set the httpx client directly, but beware that this will override any existing settings (e.g., base_url):
+
+```python
+import httpx
+from fast_api_client import Client
+
+client = Client(
+    base_url="https://api.example.com",
+)
+# Note that base_url needs to be re-set, as would any shared cookies, headers, etc.
+client.set_httpx_client(httpx.Client(base_url="https://api.example.com", proxies="http://localhost:8030"))
+```
+
+## Building / publishing this package
+This project uses [Poetry](https://python-poetry.org/) to manage dependencies  and packaging.  Here are the basics:
+1. Update the metadata in pyproject.toml (e.g. authors, version)
+1. If you're using a private repository, configure it with Poetry
+    1. `poetry config repositories.<your-repository-name> <url-to-your-repository>`
+    1. `poetry config http-basic.<your-repository-name> <username> <password>`
+1. Publish the client with `poetry publish --build -r <your-repository-name>` or, if for public PyPI, just `poetry publish --build`
+
+If you want to install this client into another project without publishing it (e.g. for development) then:
+1. If that project **is using Poetry**, you can simply do `poetry add <path-to-this-client>` from that project
+1. If that project is not using Poetry:
+    1. Build a wheel with `poetry build -f wheel`
+    1. Install that wheel from the other project `pip install <path-to-wheel>`

--- a/openapi_client/fast_api_client/__init__.py
+++ b/openapi_client/fast_api_client/__init__.py
@@ -1,0 +1,8 @@
+"""A client library for accessing FastAPI"""
+
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/openapi_client/fast_api_client/api/__init__.py
+++ b/openapi_client/fast_api_client/api/__init__.py
@@ -1,0 +1,1 @@
+"""Contains methods for accessing the API"""

--- a/openapi_client/fast_api_client/api/default/__init__.py
+++ b/openapi_client/fast_api_client/api/default/__init__.py
@@ -1,0 +1,1 @@
+"""Contains endpoint functions for accessing the API"""

--- a/openapi_client/fast_api_client/api/default/create_appointment_appointments_post.py
+++ b/openapi_client/fast_api_client/api/default/create_appointment_appointments_post.py
@@ -1,0 +1,164 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.appointment import Appointment
+from ...models.appointment_create import AppointmentCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: AppointmentCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/appointments",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Appointment, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = Appointment.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Appointment, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentCreate,
+) -> Response[Union[Appointment, HTTPValidationError]]:
+    """Create Appointment
+
+    Args:
+        body (AppointmentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Appointment, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentCreate,
+) -> Optional[Union[Appointment, HTTPValidationError]]:
+    """Create Appointment
+
+    Args:
+        body (AppointmentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Appointment, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentCreate,
+) -> Response[Union[Appointment, HTTPValidationError]]:
+    """Create Appointment
+
+    Args:
+        body (AppointmentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Appointment, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentCreate,
+) -> Optional[Union[Appointment, HTTPValidationError]]:
+    """Create Appointment
+
+    Args:
+        body (AppointmentCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Appointment, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/create_category_categories_post.py
+++ b/openapi_client/fast_api_client/api/default/create_category_categories_post.py
@@ -1,0 +1,164 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.category import Category
+from ...models.category_create import CategoryCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: CategoryCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/categories",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Category, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = Category.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Category, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Response[Union[Category, HTTPValidationError]]:
+    """Create Category
+
+    Args:
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Category, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Optional[Union[Category, HTTPValidationError]]:
+    """Create Category
+
+    Args:
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Category, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Response[Union[Category, HTTPValidationError]]:
+    """Create Category
+
+    Args:
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Category, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Optional[Union[Category, HTTPValidationError]]:
+    """Create Category
+
+    Args:
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Category, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/create_focus_session_tasks_task_id_focus_sessions_post.py
+++ b/openapi_client/fast_api_client/api/default/create_focus_session_tasks_task_id_focus_sessions_post.py
@@ -1,0 +1,177 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.focus_session import FocusSession
+from ...models.focus_session_create import FocusSessionCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    *,
+    body: FocusSessionCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": f"/tasks/{task_id}/focus_sessions",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[FocusSession, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = FocusSession.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[FocusSession, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionCreate,
+) -> Response[Union[FocusSession, HTTPValidationError]]:
+    """Create Focus Session
+
+    Args:
+        task_id (int):
+        body (FocusSessionCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[FocusSession, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionCreate,
+) -> Optional[Union[FocusSession, HTTPValidationError]]:
+    """Create Focus Session
+
+    Args:
+        task_id (int):
+        body (FocusSessionCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[FocusSession, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionCreate,
+) -> Response[Union[FocusSession, HTTPValidationError]]:
+    """Create Focus Session
+
+    Args:
+        task_id (int):
+        body (FocusSessionCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[FocusSession, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionCreate,
+) -> Optional[Union[FocusSession, HTTPValidationError]]:
+    """Create Focus Session
+
+    Args:
+        task_id (int):
+        body (FocusSessionCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[FocusSession, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/create_subtask_tasks_task_id_subtasks_post.py
+++ b/openapi_client/fast_api_client/api/default/create_subtask_tasks_task_id_subtasks_post.py
@@ -1,0 +1,177 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.subtask import Subtask
+from ...models.subtask_create import SubtaskCreate
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    *,
+    body: SubtaskCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": f"/tasks/{task_id}/subtasks",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Subtask]]:
+    if response.status_code == 200:
+        response_200 = Subtask.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Subtask]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskCreate,
+) -> Response[Union[HTTPValidationError, Subtask]]:
+    """Create Subtask
+
+    Args:
+        task_id (int):
+        body (SubtaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Subtask]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskCreate,
+) -> Optional[Union[HTTPValidationError, Subtask]]:
+    """Create Subtask
+
+    Args:
+        task_id (int):
+        body (SubtaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Subtask]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskCreate,
+) -> Response[Union[HTTPValidationError, Subtask]]:
+    """Create Subtask
+
+    Args:
+        task_id (int):
+        body (SubtaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Subtask]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskCreate,
+) -> Optional[Union[HTTPValidationError, Subtask]]:
+    """Create Subtask
+
+    Args:
+        task_id (int):
+        body (SubtaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Subtask]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/create_task_tasks_post.py
+++ b/openapi_client/fast_api_client/api/default/create_task_tasks_post.py
@@ -1,0 +1,164 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.task import Task
+from ...models.task_create import TaskCreate
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: TaskCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/tasks",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Task]]:
+    if response.status_code == 200:
+        response_200 = Task.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Task]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskCreate,
+) -> Response[Union[HTTPValidationError, Task]]:
+    """Create Task
+
+    Args:
+        body (TaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Task]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskCreate,
+) -> Optional[Union[HTTPValidationError, Task]]:
+    """Create Task
+
+    Args:
+        body (TaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Task]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskCreate,
+) -> Response[Union[HTTPValidationError, Task]]:
+    """Create Task
+
+    Args:
+        body (TaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Task]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskCreate,
+) -> Optional[Union[HTTPValidationError, Task]]:
+    """Create Task
+
+    Args:
+        body (TaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Task]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/delete_appointment_appointments_appointment_id_delete.py
+++ b/openapi_client/fast_api_client/api/default/delete_appointment_appointments_appointment_id_delete.py
@@ -1,0 +1,153 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    appointment_id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": f"/appointments/{appointment_id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Appointment
+
+    Args:
+        appointment_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        appointment_id=appointment_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Appointment
+
+    Args:
+        appointment_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        appointment_id=appointment_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Appointment
+
+    Args:
+        appointment_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        appointment_id=appointment_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Appointment
+
+    Args:
+        appointment_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            appointment_id=appointment_id,
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/delete_focus_session_tasks_task_id_focus_sessions_session_id_delete.py
+++ b/openapi_client/fast_api_client/api/default/delete_focus_session_tasks_task_id_focus_sessions_session_id_delete.py
@@ -1,0 +1,166 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    session_id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": f"/tasks/{task_id}/focus_sessions/{session_id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        session_id=session_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        session_id=session_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        session_id=session_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            session_id=session_id,
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/delete_subtask_tasks_task_id_subtasks_subtask_id_delete.py
+++ b/openapi_client/fast_api_client/api/default/delete_subtask_tasks_task_id_subtasks_subtask_id_delete.py
@@ -1,0 +1,166 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    subtask_id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": f"/tasks/{task_id}/subtasks/{subtask_id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        subtask_id=subtask_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        subtask_id=subtask_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        subtask_id=subtask_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/delete_task_tasks_task_id_delete.py
+++ b/openapi_client/fast_api_client/api/default/delete_task_tasks_task_id_delete.py
@@ -1,0 +1,153 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "delete",
+        "url": f"/tasks/{task_id}",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Any, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = response.json()
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Any, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Task
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Task
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[Any, HTTPValidationError]]:
+    """Delete Task
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[Any, HTTPValidationError]]:
+    """Delete Task
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/list_appointments_appointments_get.py
+++ b/openapi_client/fast_api_client/api/default/list_appointments_appointments_get.py
@@ -1,0 +1,131 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.appointment import Appointment
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/appointments",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[list["Appointment"]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = Appointment.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[list["Appointment"]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[list["Appointment"]]:
+    """List Appointments
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list['Appointment']]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[list["Appointment"]]:
+    """List Appointments
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list['Appointment']
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[list["Appointment"]]:
+    """List Appointments
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list['Appointment']]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[list["Appointment"]]:
+    """List Appointments
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list['Appointment']
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/list_categories_categories_get.py
+++ b/openapi_client/fast_api_client/api/default/list_categories_categories_get.py
@@ -1,0 +1,131 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.category import Category
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/categories",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[list["Category"]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = Category.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[list["Category"]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[list["Category"]]:
+    """List Categories
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list['Category']]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[list["Category"]]:
+    """List Categories
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list['Category']
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[list["Category"]]:
+    """List Categories
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list['Category']]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[list["Category"]]:
+    """List Categories
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list['Category']
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/list_focus_sessions_tasks_task_id_focus_sessions_get.py
+++ b/openapi_client/fast_api_client/api/default/list_focus_sessions_tasks_task_id_focus_sessions_get.py
@@ -1,0 +1,160 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.focus_session import FocusSession
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": f"/tasks/{task_id}/focus_sessions",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, list["FocusSession"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = FocusSession.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, list["FocusSession"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["FocusSession"]]]:
+    """List Focus Sessions
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['FocusSession']]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["FocusSession"]]]:
+    """List Focus Sessions
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['FocusSession']]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["FocusSession"]]]:
+    """List Focus Sessions
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['FocusSession']]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["FocusSession"]]]:
+    """List Focus Sessions
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['FocusSession']]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/list_subtasks_tasks_task_id_subtasks_get.py
+++ b/openapi_client/fast_api_client/api/default/list_subtasks_tasks_task_id_subtasks_get.py
@@ -1,0 +1,160 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.subtask import Subtask
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+) -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": f"/tasks/{task_id}/subtasks",
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, list["Subtask"]]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = Subtask.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, list["Subtask"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["Subtask"]]]:
+    """List Subtasks
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['Subtask']]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["Subtask"]]]:
+    """List Subtasks
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['Subtask']]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[Union[HTTPValidationError, list["Subtask"]]]:
+    """List Subtasks
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, list['Subtask']]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[Union[HTTPValidationError, list["Subtask"]]]:
+    """List Subtasks
+
+    Args:
+        task_id (int):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, list['Subtask']]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/list_tasks_tasks_get.py
+++ b/openapi_client/fast_api_client/api/default/list_tasks_tasks_get.py
@@ -1,0 +1,127 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.task import Task
+from ...types import Response
+
+
+def _get_kwargs() -> dict[str, Any]:
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/tasks",
+    }
+
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[list["Task"]]:
+    if response.status_code == 200:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = Task.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[list["Task"]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[list["Task"]]:
+    """List Tasks
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list['Task']]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[list["Task"]]:
+    """List Tasks
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list['Task']
+    """
+
+    return sync_detailed(
+        client=client,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Response[list["Task"]]:
+    """List Tasks
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[list['Task']]
+    """
+
+    kwargs = _get_kwargs()
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+) -> Optional[list["Task"]]:
+    """List Tasks
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        list['Task']
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/plan_task_tasks_plan_post.py
+++ b/openapi_client/fast_api_client/api/default/plan_task_tasks_plan_post.py
@@ -1,0 +1,164 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.plan_task_create import PlanTaskCreate
+from ...models.task import Task
+from ...types import Response
+
+
+def _get_kwargs(
+    *,
+    body: PlanTaskCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "post",
+        "url": "/tasks/plan",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Task]]:
+    if response.status_code == 200:
+        response_200 = Task.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Task]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: PlanTaskCreate,
+) -> Response[Union[HTTPValidationError, Task]]:
+    """Plan Task
+
+    Args:
+        body (PlanTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Task]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: PlanTaskCreate,
+) -> Optional[Union[HTTPValidationError, Task]]:
+    """Plan Task
+
+    Args:
+        body (PlanTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Task]
+    """
+
+    return sync_detailed(
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: PlanTaskCreate,
+) -> Response[Union[HTTPValidationError, Task]]:
+    """Plan Task
+
+    Args:
+        body (PlanTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Task]]
+    """
+
+    kwargs = _get_kwargs(
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: PlanTaskCreate,
+) -> Optional[Union[HTTPValidationError, Task]]:
+    """Plan Task
+
+    Args:
+        body (PlanTaskCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Task]
+    """
+
+    return (
+        await asyncio_detailed(
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/update_appointment_appointments_appointment_id_put.py
+++ b/openapi_client/fast_api_client/api/default/update_appointment_appointments_appointment_id_put.py
@@ -1,0 +1,177 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.appointment import Appointment
+from ...models.appointment_update import AppointmentUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    appointment_id: int,
+    *,
+    body: AppointmentUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/appointments/{appointment_id}",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Appointment, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = Appointment.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Appointment, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentUpdate,
+) -> Response[Union[Appointment, HTTPValidationError]]:
+    """Update Appointment
+
+    Args:
+        appointment_id (int):
+        body (AppointmentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Appointment, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        appointment_id=appointment_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentUpdate,
+) -> Optional[Union[Appointment, HTTPValidationError]]:
+    """Update Appointment
+
+    Args:
+        appointment_id (int):
+        body (AppointmentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Appointment, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        appointment_id=appointment_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentUpdate,
+) -> Response[Union[Appointment, HTTPValidationError]]:
+    """Update Appointment
+
+    Args:
+        appointment_id (int):
+        body (AppointmentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Appointment, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        appointment_id=appointment_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    appointment_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: AppointmentUpdate,
+) -> Optional[Union[Appointment, HTTPValidationError]]:
+    """Update Appointment
+
+    Args:
+        appointment_id (int):
+        body (AppointmentUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Appointment, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            appointment_id=appointment_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/update_category_categories_category_id_put.py
+++ b/openapi_client/fast_api_client/api/default/update_category_categories_category_id_put.py
@@ -1,0 +1,177 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.category import Category
+from ...models.category_create import CategoryCreate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    category_id: int,
+    *,
+    body: CategoryCreate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/categories/{category_id}",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[Category, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = Category.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[Category, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    category_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Response[Union[Category, HTTPValidationError]]:
+    """Update Category
+
+    Args:
+        category_id (int):
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Category, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        category_id=category_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    category_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Optional[Union[Category, HTTPValidationError]]:
+    """Update Category
+
+    Args:
+        category_id (int):
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Category, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        category_id=category_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    category_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Response[Union[Category, HTTPValidationError]]:
+    """Update Category
+
+    Args:
+        category_id (int):
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Category, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        category_id=category_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    category_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: CategoryCreate,
+) -> Optional[Union[Category, HTTPValidationError]]:
+    """Update Category
+
+    Args:
+        category_id (int):
+        body (CategoryCreate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Category, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            category_id=category_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/update_focus_session_tasks_task_id_focus_sessions_session_id_put.py
+++ b/openapi_client/fast_api_client/api/default/update_focus_session_tasks_task_id_focus_sessions_session_id_put.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.focus_session import FocusSession
+from ...models.focus_session_update import FocusSessionUpdate
+from ...models.http_validation_error import HTTPValidationError
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    session_id: int,
+    *,
+    body: FocusSessionUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/tasks/{task_id}/focus_sessions/{session_id}",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[FocusSession, HTTPValidationError]]:
+    if response.status_code == 200:
+        response_200 = FocusSession.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[FocusSession, HTTPValidationError]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionUpdate,
+) -> Response[Union[FocusSession, HTTPValidationError]]:
+    """Update Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+        body (FocusSessionUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[FocusSession, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        session_id=session_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionUpdate,
+) -> Optional[Union[FocusSession, HTTPValidationError]]:
+    """Update Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+        body (FocusSessionUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[FocusSession, HTTPValidationError]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        session_id=session_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionUpdate,
+) -> Response[Union[FocusSession, HTTPValidationError]]:
+    """Update Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+        body (FocusSessionUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[FocusSession, HTTPValidationError]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        session_id=session_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    session_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: FocusSessionUpdate,
+) -> Optional[Union[FocusSession, HTTPValidationError]]:
+    """Update Focus Session
+
+    Args:
+        task_id (int):
+        session_id (int):
+        body (FocusSessionUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[FocusSession, HTTPValidationError]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            session_id=session_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/update_subtask_tasks_task_id_subtasks_subtask_id_put.py
+++ b/openapi_client/fast_api_client/api/default/update_subtask_tasks_task_id_subtasks_subtask_id_put.py
@@ -1,0 +1,190 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.subtask import Subtask
+from ...models.subtask_update import SubtaskUpdate
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    subtask_id: int,
+    *,
+    body: SubtaskUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/tasks/{task_id}/subtasks/{subtask_id}",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Subtask]]:
+    if response.status_code == 200:
+        response_200 = Subtask.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Subtask]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskUpdate,
+) -> Response[Union[HTTPValidationError, Subtask]]:
+    """Update Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+        body (SubtaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Subtask]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        subtask_id=subtask_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskUpdate,
+) -> Optional[Union[HTTPValidationError, Subtask]]:
+    """Update Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+        body (SubtaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Subtask]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        subtask_id=subtask_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskUpdate,
+) -> Response[Union[HTTPValidationError, Subtask]]:
+    """Update Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+        body (SubtaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Subtask]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        subtask_id=subtask_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    subtask_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: SubtaskUpdate,
+) -> Optional[Union[HTTPValidationError, Subtask]]:
+    """Update Subtask
+
+    Args:
+        task_id (int):
+        subtask_id (int):
+        body (SubtaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Subtask]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            subtask_id=subtask_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/api/default/update_task_tasks_task_id_put.py
+++ b/openapi_client/fast_api_client/api/default/update_task_tasks_task_id_put.py
@@ -1,0 +1,177 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.http_validation_error import HTTPValidationError
+from ...models.task import Task
+from ...models.task_update import TaskUpdate
+from ...types import Response
+
+
+def _get_kwargs(
+    task_id: int,
+    *,
+    body: TaskUpdate,
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+
+    _kwargs: dict[str, Any] = {
+        "method": "put",
+        "url": f"/tasks/{task_id}",
+    }
+
+    _kwargs["json"] = body.to_dict()
+
+    headers["Content-Type"] = "application/json"
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPValidationError, Task]]:
+    if response.status_code == 200:
+        response_200 = Task.from_dict(response.json())
+
+        return response_200
+    if response.status_code == 422:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPValidationError, Task]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskUpdate,
+) -> Response[Union[HTTPValidationError, Task]]:
+    """Update Task
+
+    Args:
+        task_id (int):
+        body (TaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Task]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        body=body,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskUpdate,
+) -> Optional[Union[HTTPValidationError, Task]]:
+    """Update Task
+
+    Args:
+        task_id (int):
+        body (TaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Task]
+    """
+
+    return sync_detailed(
+        task_id=task_id,
+        client=client,
+        body=body,
+    ).parsed
+
+
+async def asyncio_detailed(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskUpdate,
+) -> Response[Union[HTTPValidationError, Task]]:
+    """Update Task
+
+    Args:
+        task_id (int):
+        body (TaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPValidationError, Task]]
+    """
+
+    kwargs = _get_kwargs(
+        task_id=task_id,
+        body=body,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    task_id: int,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    body: TaskUpdate,
+) -> Optional[Union[HTTPValidationError, Task]]:
+    """Update Task
+
+    Args:
+        task_id (int):
+        body (TaskUpdate):
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPValidationError, Task]
+    """
+
+    return (
+        await asyncio_detailed(
+            task_id=task_id,
+            client=client,
+            body=body,
+        )
+    ).parsed

--- a/openapi_client/fast_api_client/client.py
+++ b/openapi_client/fast_api_client/client.py
@@ -1,0 +1,268 @@
+import ssl
+from typing import Any, Optional, Union
+
+import httpx
+from attrs import define, evolve, field
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)

--- a/openapi_client/fast_api_client/errors.py
+++ b/openapi_client/fast_api_client/errors.py
@@ -1,0 +1,16 @@
+"""Contains shared errors types that can be raised from API functions"""
+
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+
+__all__ = ["UnexpectedStatus"]

--- a/openapi_client/fast_api_client/models/__init__.py
+++ b/openapi_client/fast_api_client/models/__init__.py
@@ -1,0 +1,39 @@
+"""Contains all the data models used in inputs/outputs"""
+
+from .appointment import Appointment
+from .appointment_create import AppointmentCreate
+from .appointment_update import AppointmentUpdate
+from .category import Category
+from .category_create import CategoryCreate
+from .focus_session import FocusSession
+from .focus_session_create import FocusSessionCreate
+from .focus_session_update import FocusSessionUpdate
+from .http_validation_error import HTTPValidationError
+from .plan_task_create import PlanTaskCreate
+from .subtask import Subtask
+from .subtask_create import SubtaskCreate
+from .subtask_update import SubtaskUpdate
+from .task import Task
+from .task_create import TaskCreate
+from .task_update import TaskUpdate
+from .validation_error import ValidationError
+
+__all__ = (
+    "Appointment",
+    "AppointmentCreate",
+    "AppointmentUpdate",
+    "Category",
+    "CategoryCreate",
+    "FocusSession",
+    "FocusSessionCreate",
+    "FocusSessionUpdate",
+    "HTTPValidationError",
+    "PlanTaskCreate",
+    "Subtask",
+    "SubtaskCreate",
+    "SubtaskUpdate",
+    "Task",
+    "TaskCreate",
+    "TaskUpdate",
+    "ValidationError",
+)

--- a/openapi_client/fast_api_client/models/appointment.py
+++ b/openapi_client/fast_api_client/models/appointment.py
@@ -1,0 +1,127 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Appointment")
+
+
+@_attrs_define
+class Appointment:
+    """
+    Attributes:
+        title (str):
+        start_time (datetime.datetime):
+        end_time (datetime.datetime):
+        id (int):
+        description (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+    """
+
+    title: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    id: int
+    description: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        start_time = self.start_time.isoformat()
+
+        end_time = self.end_time.isoformat()
+
+        id = self.id
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "start_time": start_time,
+                "end_time": end_time,
+                "id": id,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        start_time = isoparse(d.pop("start_time"))
+
+        end_time = isoparse(d.pop("end_time"))
+
+        id = d.pop("id")
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        appointment = cls(
+            title=title,
+            start_time=start_time,
+            end_time=end_time,
+            id=id,
+            description=description,
+            category_id=category_id,
+        )
+
+        appointment.additional_properties = d
+        return appointment
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/appointment_create.py
+++ b/openapi_client/fast_api_client/models/appointment_create.py
@@ -1,0 +1,119 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AppointmentCreate")
+
+
+@_attrs_define
+class AppointmentCreate:
+    """
+    Attributes:
+        title (str):
+        start_time (datetime.datetime):
+        end_time (datetime.datetime):
+        description (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+    """
+
+    title: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    description: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        start_time = self.start_time.isoformat()
+
+        end_time = self.end_time.isoformat()
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "start_time": start_time,
+                "end_time": end_time,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        start_time = isoparse(d.pop("start_time"))
+
+        end_time = isoparse(d.pop("end_time"))
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        appointment_create = cls(
+            title=title,
+            start_time=start_time,
+            end_time=end_time,
+            description=description,
+            category_id=category_id,
+        )
+
+        appointment_create.additional_properties = d
+        return appointment_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/appointment_update.py
+++ b/openapi_client/fast_api_client/models/appointment_update.py
@@ -1,0 +1,119 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="AppointmentUpdate")
+
+
+@_attrs_define
+class AppointmentUpdate:
+    """
+    Attributes:
+        title (str):
+        start_time (datetime.datetime):
+        end_time (datetime.datetime):
+        description (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+    """
+
+    title: str
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    description: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        start_time = self.start_time.isoformat()
+
+        end_time = self.end_time.isoformat()
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "start_time": start_time,
+                "end_time": end_time,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        start_time = isoparse(d.pop("start_time"))
+
+        end_time = isoparse(d.pop("end_time"))
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        appointment_update = cls(
+            title=title,
+            start_time=start_time,
+            end_time=end_time,
+            description=description,
+            category_id=category_id,
+        )
+
+        appointment_update.additional_properties = d
+        return appointment_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/category.py
+++ b/openapi_client/fast_api_client/models/category.py
@@ -1,0 +1,148 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Category")
+
+
+@_attrs_define
+class Category:
+    """
+    Attributes:
+        name (str):
+        color (str):
+        id (int):
+        preferred_start_hour (Union[None, Unset, int]):
+        preferred_end_hour (Union[None, Unset, int]):
+        energy_curve (Union[None, Unset, list[int]]):
+    """
+
+    name: str
+    color: str
+    id: int
+    preferred_start_hour: Union[None, Unset, int] = UNSET
+    preferred_end_hour: Union[None, Unset, int] = UNSET
+    energy_curve: Union[None, Unset, list[int]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        color = self.color
+
+        id = self.id
+
+        preferred_start_hour: Union[None, Unset, int]
+        if isinstance(self.preferred_start_hour, Unset):
+            preferred_start_hour = UNSET
+        else:
+            preferred_start_hour = self.preferred_start_hour
+
+        preferred_end_hour: Union[None, Unset, int]
+        if isinstance(self.preferred_end_hour, Unset):
+            preferred_end_hour = UNSET
+        else:
+            preferred_end_hour = self.preferred_end_hour
+
+        energy_curve: Union[None, Unset, list[int]]
+        if isinstance(self.energy_curve, Unset):
+            energy_curve = UNSET
+        elif isinstance(self.energy_curve, list):
+            energy_curve = self.energy_curve
+
+        else:
+            energy_curve = self.energy_curve
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "color": color,
+                "id": id,
+            }
+        )
+        if preferred_start_hour is not UNSET:
+            field_dict["preferred_start_hour"] = preferred_start_hour
+        if preferred_end_hour is not UNSET:
+            field_dict["preferred_end_hour"] = preferred_end_hour
+        if energy_curve is not UNSET:
+            field_dict["energy_curve"] = energy_curve
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        color = d.pop("color")
+
+        id = d.pop("id")
+
+        def _parse_preferred_start_hour(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        preferred_start_hour = _parse_preferred_start_hour(d.pop("preferred_start_hour", UNSET))
+
+        def _parse_preferred_end_hour(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        preferred_end_hour = _parse_preferred_end_hour(d.pop("preferred_end_hour", UNSET))
+
+        def _parse_energy_curve(data: object) -> Union[None, Unset, list[int]]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                energy_curve_type_0 = cast(list[int], data)
+
+                return energy_curve_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, list[int]], data)
+
+        energy_curve = _parse_energy_curve(d.pop("energy_curve", UNSET))
+
+        category = cls(
+            name=name,
+            color=color,
+            id=id,
+            preferred_start_hour=preferred_start_hour,
+            preferred_end_hour=preferred_end_hour,
+            energy_curve=energy_curve,
+        )
+
+        category.additional_properties = d
+        return category
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/category_create.py
+++ b/openapi_client/fast_api_client/models/category_create.py
@@ -1,0 +1,140 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="CategoryCreate")
+
+
+@_attrs_define
+class CategoryCreate:
+    """
+    Attributes:
+        name (str):
+        color (str):
+        preferred_start_hour (Union[None, Unset, int]):
+        preferred_end_hour (Union[None, Unset, int]):
+        energy_curve (Union[None, Unset, list[int]]):
+    """
+
+    name: str
+    color: str
+    preferred_start_hour: Union[None, Unset, int] = UNSET
+    preferred_end_hour: Union[None, Unset, int] = UNSET
+    energy_curve: Union[None, Unset, list[int]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        name = self.name
+
+        color = self.color
+
+        preferred_start_hour: Union[None, Unset, int]
+        if isinstance(self.preferred_start_hour, Unset):
+            preferred_start_hour = UNSET
+        else:
+            preferred_start_hour = self.preferred_start_hour
+
+        preferred_end_hour: Union[None, Unset, int]
+        if isinstance(self.preferred_end_hour, Unset):
+            preferred_end_hour = UNSET
+        else:
+            preferred_end_hour = self.preferred_end_hour
+
+        energy_curve: Union[None, Unset, list[int]]
+        if isinstance(self.energy_curve, Unset):
+            energy_curve = UNSET
+        elif isinstance(self.energy_curve, list):
+            energy_curve = self.energy_curve
+
+        else:
+            energy_curve = self.energy_curve
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "name": name,
+                "color": color,
+            }
+        )
+        if preferred_start_hour is not UNSET:
+            field_dict["preferred_start_hour"] = preferred_start_hour
+        if preferred_end_hour is not UNSET:
+            field_dict["preferred_end_hour"] = preferred_end_hour
+        if energy_curve is not UNSET:
+            field_dict["energy_curve"] = energy_curve
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        name = d.pop("name")
+
+        color = d.pop("color")
+
+        def _parse_preferred_start_hour(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        preferred_start_hour = _parse_preferred_start_hour(d.pop("preferred_start_hour", UNSET))
+
+        def _parse_preferred_end_hour(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        preferred_end_hour = _parse_preferred_end_hour(d.pop("preferred_end_hour", UNSET))
+
+        def _parse_energy_curve(data: object) -> Union[None, Unset, list[int]]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                energy_curve_type_0 = cast(list[int], data)
+
+                return energy_curve_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, list[int]], data)
+
+        energy_curve = _parse_energy_curve(d.pop("energy_curve", UNSET))
+
+        category_create = cls(
+            name=name,
+            color=color,
+            preferred_start_hour=preferred_start_hour,
+            preferred_end_hour=preferred_end_hour,
+            energy_curve=energy_curve,
+        )
+
+        category_create.additional_properties = d
+        return category_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/focus_session.py
+++ b/openapi_client/fast_api_client/models/focus_session.py
@@ -1,0 +1,96 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="FocusSession")
+
+
+@_attrs_define
+class FocusSession:
+    """
+    Attributes:
+        start_time (datetime.datetime):
+        end_time (datetime.datetime):
+        id (int):
+        task_id (int):
+        completed (Union[Unset, bool]):  Default: False.
+    """
+
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    id: int
+    task_id: int
+    completed: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        start_time = self.start_time.isoformat()
+
+        end_time = self.end_time.isoformat()
+
+        id = self.id
+
+        task_id = self.task_id
+
+        completed = self.completed
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "start_time": start_time,
+                "end_time": end_time,
+                "id": id,
+                "task_id": task_id,
+            }
+        )
+        if completed is not UNSET:
+            field_dict["completed"] = completed
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        start_time = isoparse(d.pop("start_time"))
+
+        end_time = isoparse(d.pop("end_time"))
+
+        id = d.pop("id")
+
+        task_id = d.pop("task_id")
+
+        completed = d.pop("completed", UNSET)
+
+        focus_session = cls(
+            start_time=start_time,
+            end_time=end_time,
+            id=id,
+            task_id=task_id,
+            completed=completed,
+        )
+
+        focus_session.additional_properties = d
+        return focus_session
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/focus_session_create.py
+++ b/openapi_client/fast_api_client/models/focus_session_create.py
@@ -1,0 +1,93 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="FocusSessionCreate")
+
+
+@_attrs_define
+class FocusSessionCreate:
+    """
+    Attributes:
+        duration_minutes (int):
+        start_time (Union[None, Unset, datetime.datetime]):
+    """
+
+    duration_minutes: int
+    start_time: Union[None, Unset, datetime.datetime] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        duration_minutes = self.duration_minutes
+
+        start_time: Union[None, Unset, str]
+        if isinstance(self.start_time, Unset):
+            start_time = UNSET
+        elif isinstance(self.start_time, datetime.datetime):
+            start_time = self.start_time.isoformat()
+        else:
+            start_time = self.start_time
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "duration_minutes": duration_minutes,
+            }
+        )
+        if start_time is not UNSET:
+            field_dict["start_time"] = start_time
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        duration_minutes = d.pop("duration_minutes")
+
+        def _parse_start_time(data: object) -> Union[None, Unset, datetime.datetime]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                start_time_type_0 = isoparse(data)
+
+                return start_time_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.datetime], data)
+
+        start_time = _parse_start_time(d.pop("start_time", UNSET))
+
+        focus_session_create = cls(
+            duration_minutes=duration_minutes,
+            start_time=start_time,
+        )
+
+        focus_session_create.additional_properties = d
+        return focus_session_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/focus_session_update.py
+++ b/openapi_client/fast_api_client/models/focus_session_update.py
@@ -1,0 +1,103 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="FocusSessionUpdate")
+
+
+@_attrs_define
+class FocusSessionUpdate:
+    """
+    Attributes:
+        end_time (Union[None, Unset, datetime.datetime]):
+        completed (Union[None, Unset, bool]):
+    """
+
+    end_time: Union[None, Unset, datetime.datetime] = UNSET
+    completed: Union[None, Unset, bool] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        end_time: Union[None, Unset, str]
+        if isinstance(self.end_time, Unset):
+            end_time = UNSET
+        elif isinstance(self.end_time, datetime.datetime):
+            end_time = self.end_time.isoformat()
+        else:
+            end_time = self.end_time
+
+        completed: Union[None, Unset, bool]
+        if isinstance(self.completed, Unset):
+            completed = UNSET
+        else:
+            completed = self.completed
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if end_time is not UNSET:
+            field_dict["end_time"] = end_time
+        if completed is not UNSET:
+            field_dict["completed"] = completed
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+
+        def _parse_end_time(data: object) -> Union[None, Unset, datetime.datetime]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                end_time_type_0 = isoparse(data)
+
+                return end_time_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.datetime], data)
+
+        end_time = _parse_end_time(d.pop("end_time", UNSET))
+
+        def _parse_completed(data: object) -> Union[None, Unset, bool]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, bool], data)
+
+        completed = _parse_completed(d.pop("completed", UNSET))
+
+        focus_session_update = cls(
+            end_time=end_time,
+            completed=completed,
+        )
+
+        focus_session_update.additional_properties = d
+        return focus_session_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/http_validation_error.py
+++ b/openapi_client/fast_api_client/models/http_validation_error.py
@@ -1,0 +1,75 @@
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+if TYPE_CHECKING:
+    from ..models.validation_error import ValidationError
+
+
+T = TypeVar("T", bound="HTTPValidationError")
+
+
+@_attrs_define
+class HTTPValidationError:
+    """
+    Attributes:
+        detail (Union[Unset, list['ValidationError']]):
+    """
+
+    detail: Union[Unset, list["ValidationError"]] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        detail: Union[Unset, list[dict[str, Any]]] = UNSET
+        if not isinstance(self.detail, Unset):
+            detail = []
+            for detail_item_data in self.detail:
+                detail_item = detail_item_data.to_dict()
+                detail.append(detail_item)
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.validation_error import ValidationError
+
+        d = dict(src_dict)
+        detail = []
+        _detail = d.pop("detail", UNSET)
+        for detail_item_data in _detail or []:
+            detail_item = ValidationError.from_dict(detail_item_data)
+
+            detail.append(detail_item)
+
+        http_validation_error = cls(
+            detail=detail,
+        )
+
+        http_validation_error.additional_properties = d
+        return http_validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/plan_task_create.py
+++ b/openapi_client/fast_api_client/models/plan_task_create.py
@@ -1,0 +1,449 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="PlanTaskCreate")
+
+
+@_attrs_define
+class PlanTaskCreate:
+    """
+    Attributes:
+        title (str):
+        estimated_difficulty (int):
+        estimated_duration_minutes (int):
+        due_date (datetime.date):
+        description (Union[None, Unset, str]):
+        priority (Union[Unset, int]):  Default: 3.
+        category_id (Union[None, Unset, int]):
+        high_energy_start_hour (Union[None, Unset, int]):
+        high_energy_end_hour (Union[None, Unset, int]):
+        fatigue_break_factor (Union[None, Unset, float]):
+        energy_curve (Union[None, Unset, list[int]]):
+        energy_day_order_weight (Union[None, Unset, float]):
+        category_day_weight (Union[None, Unset, float]):
+        transition_buffer_minutes (Union[None, Unset, int]):
+        intelligent_transition_buffer (Union[None, Unset, bool]):
+        productivity_history_weight (Union[None, Unset, float]):
+        productivity_half_life_days (Union[None, Unset, int]):
+        category_productivity_weight (Union[None, Unset, float]):
+        spaced_repetition_factor (Union[None, Unset, float]):
+        session_count_weight (Union[None, Unset, float]):
+        difficulty_load_weight (Union[None, Unset, float]):
+        energy_load_weight (Union[None, Unset, float]):
+    """
+
+    title: str
+    estimated_difficulty: int
+    estimated_duration_minutes: int
+    due_date: datetime.date
+    description: Union[None, Unset, str] = UNSET
+    priority: Union[Unset, int] = 3
+    category_id: Union[None, Unset, int] = UNSET
+    high_energy_start_hour: Union[None, Unset, int] = UNSET
+    high_energy_end_hour: Union[None, Unset, int] = UNSET
+    fatigue_break_factor: Union[None, Unset, float] = UNSET
+    energy_curve: Union[None, Unset, list[int]] = UNSET
+    energy_day_order_weight: Union[None, Unset, float] = UNSET
+    category_day_weight: Union[None, Unset, float] = UNSET
+    transition_buffer_minutes: Union[None, Unset, int] = UNSET
+    intelligent_transition_buffer: Union[None, Unset, bool] = UNSET
+    productivity_history_weight: Union[None, Unset, float] = UNSET
+    productivity_half_life_days: Union[None, Unset, int] = UNSET
+    category_productivity_weight: Union[None, Unset, float] = UNSET
+    spaced_repetition_factor: Union[None, Unset, float] = UNSET
+    session_count_weight: Union[None, Unset, float] = UNSET
+    difficulty_load_weight: Union[None, Unset, float] = UNSET
+    energy_load_weight: Union[None, Unset, float] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        estimated_difficulty = self.estimated_difficulty
+
+        estimated_duration_minutes = self.estimated_duration_minutes
+
+        due_date = self.due_date.isoformat()
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        priority = self.priority
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        high_energy_start_hour: Union[None, Unset, int]
+        if isinstance(self.high_energy_start_hour, Unset):
+            high_energy_start_hour = UNSET
+        else:
+            high_energy_start_hour = self.high_energy_start_hour
+
+        high_energy_end_hour: Union[None, Unset, int]
+        if isinstance(self.high_energy_end_hour, Unset):
+            high_energy_end_hour = UNSET
+        else:
+            high_energy_end_hour = self.high_energy_end_hour
+
+        fatigue_break_factor: Union[None, Unset, float]
+        if isinstance(self.fatigue_break_factor, Unset):
+            fatigue_break_factor = UNSET
+        else:
+            fatigue_break_factor = self.fatigue_break_factor
+
+        energy_curve: Union[None, Unset, list[int]]
+        if isinstance(self.energy_curve, Unset):
+            energy_curve = UNSET
+        elif isinstance(self.energy_curve, list):
+            energy_curve = self.energy_curve
+
+        else:
+            energy_curve = self.energy_curve
+
+        energy_day_order_weight: Union[None, Unset, float]
+        if isinstance(self.energy_day_order_weight, Unset):
+            energy_day_order_weight = UNSET
+        else:
+            energy_day_order_weight = self.energy_day_order_weight
+
+        category_day_weight: Union[None, Unset, float]
+        if isinstance(self.category_day_weight, Unset):
+            category_day_weight = UNSET
+        else:
+            category_day_weight = self.category_day_weight
+
+        transition_buffer_minutes: Union[None, Unset, int]
+        if isinstance(self.transition_buffer_minutes, Unset):
+            transition_buffer_minutes = UNSET
+        else:
+            transition_buffer_minutes = self.transition_buffer_minutes
+
+        intelligent_transition_buffer: Union[None, Unset, bool]
+        if isinstance(self.intelligent_transition_buffer, Unset):
+            intelligent_transition_buffer = UNSET
+        else:
+            intelligent_transition_buffer = self.intelligent_transition_buffer
+
+        productivity_history_weight: Union[None, Unset, float]
+        if isinstance(self.productivity_history_weight, Unset):
+            productivity_history_weight = UNSET
+        else:
+            productivity_history_weight = self.productivity_history_weight
+
+        productivity_half_life_days: Union[None, Unset, int]
+        if isinstance(self.productivity_half_life_days, Unset):
+            productivity_half_life_days = UNSET
+        else:
+            productivity_half_life_days = self.productivity_half_life_days
+
+        category_productivity_weight: Union[None, Unset, float]
+        if isinstance(self.category_productivity_weight, Unset):
+            category_productivity_weight = UNSET
+        else:
+            category_productivity_weight = self.category_productivity_weight
+
+        spaced_repetition_factor: Union[None, Unset, float]
+        if isinstance(self.spaced_repetition_factor, Unset):
+            spaced_repetition_factor = UNSET
+        else:
+            spaced_repetition_factor = self.spaced_repetition_factor
+
+        session_count_weight: Union[None, Unset, float]
+        if isinstance(self.session_count_weight, Unset):
+            session_count_weight = UNSET
+        else:
+            session_count_weight = self.session_count_weight
+
+        difficulty_load_weight: Union[None, Unset, float]
+        if isinstance(self.difficulty_load_weight, Unset):
+            difficulty_load_weight = UNSET
+        else:
+            difficulty_load_weight = self.difficulty_load_weight
+
+        energy_load_weight: Union[None, Unset, float]
+        if isinstance(self.energy_load_weight, Unset):
+            energy_load_weight = UNSET
+        else:
+            energy_load_weight = self.energy_load_weight
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "estimated_difficulty": estimated_difficulty,
+                "estimated_duration_minutes": estimated_duration_minutes,
+                "due_date": due_date,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if priority is not UNSET:
+            field_dict["priority"] = priority
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+        if high_energy_start_hour is not UNSET:
+            field_dict["high_energy_start_hour"] = high_energy_start_hour
+        if high_energy_end_hour is not UNSET:
+            field_dict["high_energy_end_hour"] = high_energy_end_hour
+        if fatigue_break_factor is not UNSET:
+            field_dict["fatigue_break_factor"] = fatigue_break_factor
+        if energy_curve is not UNSET:
+            field_dict["energy_curve"] = energy_curve
+        if energy_day_order_weight is not UNSET:
+            field_dict["energy_day_order_weight"] = energy_day_order_weight
+        if category_day_weight is not UNSET:
+            field_dict["category_day_weight"] = category_day_weight
+        if transition_buffer_minutes is not UNSET:
+            field_dict["transition_buffer_minutes"] = transition_buffer_minutes
+        if intelligent_transition_buffer is not UNSET:
+            field_dict["intelligent_transition_buffer"] = intelligent_transition_buffer
+        if productivity_history_weight is not UNSET:
+            field_dict["productivity_history_weight"] = productivity_history_weight
+        if productivity_half_life_days is not UNSET:
+            field_dict["productivity_half_life_days"] = productivity_half_life_days
+        if category_productivity_weight is not UNSET:
+            field_dict["category_productivity_weight"] = category_productivity_weight
+        if spaced_repetition_factor is not UNSET:
+            field_dict["spaced_repetition_factor"] = spaced_repetition_factor
+        if session_count_weight is not UNSET:
+            field_dict["session_count_weight"] = session_count_weight
+        if difficulty_load_weight is not UNSET:
+            field_dict["difficulty_load_weight"] = difficulty_load_weight
+        if energy_load_weight is not UNSET:
+            field_dict["energy_load_weight"] = energy_load_weight
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        estimated_difficulty = d.pop("estimated_difficulty")
+
+        estimated_duration_minutes = d.pop("estimated_duration_minutes")
+
+        due_date = isoparse(d.pop("due_date")).date()
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        priority = d.pop("priority", UNSET)
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        def _parse_high_energy_start_hour(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        high_energy_start_hour = _parse_high_energy_start_hour(d.pop("high_energy_start_hour", UNSET))
+
+        def _parse_high_energy_end_hour(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        high_energy_end_hour = _parse_high_energy_end_hour(d.pop("high_energy_end_hour", UNSET))
+
+        def _parse_fatigue_break_factor(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        fatigue_break_factor = _parse_fatigue_break_factor(d.pop("fatigue_break_factor", UNSET))
+
+        def _parse_energy_curve(data: object) -> Union[None, Unset, list[int]]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, list):
+                    raise TypeError()
+                energy_curve_type_0 = cast(list[int], data)
+
+                return energy_curve_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, list[int]], data)
+
+        energy_curve = _parse_energy_curve(d.pop("energy_curve", UNSET))
+
+        def _parse_energy_day_order_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        energy_day_order_weight = _parse_energy_day_order_weight(d.pop("energy_day_order_weight", UNSET))
+
+        def _parse_category_day_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        category_day_weight = _parse_category_day_weight(d.pop("category_day_weight", UNSET))
+
+        def _parse_transition_buffer_minutes(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        transition_buffer_minutes = _parse_transition_buffer_minutes(d.pop("transition_buffer_minutes", UNSET))
+
+        def _parse_intelligent_transition_buffer(data: object) -> Union[None, Unset, bool]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, bool], data)
+
+        intelligent_transition_buffer = _parse_intelligent_transition_buffer(
+            d.pop("intelligent_transition_buffer", UNSET)
+        )
+
+        def _parse_productivity_history_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        productivity_history_weight = _parse_productivity_history_weight(d.pop("productivity_history_weight", UNSET))
+
+        def _parse_productivity_half_life_days(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        productivity_half_life_days = _parse_productivity_half_life_days(d.pop("productivity_half_life_days", UNSET))
+
+        def _parse_category_productivity_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        category_productivity_weight = _parse_category_productivity_weight(d.pop("category_productivity_weight", UNSET))
+
+        def _parse_spaced_repetition_factor(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        spaced_repetition_factor = _parse_spaced_repetition_factor(d.pop("spaced_repetition_factor", UNSET))
+
+        def _parse_session_count_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        session_count_weight = _parse_session_count_weight(d.pop("session_count_weight", UNSET))
+
+        def _parse_difficulty_load_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        difficulty_load_weight = _parse_difficulty_load_weight(d.pop("difficulty_load_weight", UNSET))
+
+        def _parse_energy_load_weight(data: object) -> Union[None, Unset, float]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, float], data)
+
+        energy_load_weight = _parse_energy_load_weight(d.pop("energy_load_weight", UNSET))
+
+        plan_task_create = cls(
+            title=title,
+            estimated_difficulty=estimated_difficulty,
+            estimated_duration_minutes=estimated_duration_minutes,
+            due_date=due_date,
+            description=description,
+            priority=priority,
+            category_id=category_id,
+            high_energy_start_hour=high_energy_start_hour,
+            high_energy_end_hour=high_energy_end_hour,
+            fatigue_break_factor=fatigue_break_factor,
+            energy_curve=energy_curve,
+            energy_day_order_weight=energy_day_order_weight,
+            category_day_weight=category_day_weight,
+            transition_buffer_minutes=transition_buffer_minutes,
+            intelligent_transition_buffer=intelligent_transition_buffer,
+            productivity_history_weight=productivity_history_weight,
+            productivity_half_life_days=productivity_half_life_days,
+            category_productivity_weight=category_productivity_weight,
+            spaced_repetition_factor=spaced_repetition_factor,
+            session_count_weight=session_count_weight,
+            difficulty_load_weight=difficulty_load_weight,
+            energy_load_weight=energy_load_weight,
+        )
+
+        plan_task_create.additional_properties = d
+        return plan_task_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/subtask.py
+++ b/openapi_client/fast_api_client/models/subtask.py
@@ -1,0 +1,86 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Subtask")
+
+
+@_attrs_define
+class Subtask:
+    """
+    Attributes:
+        title (str):
+        id (int):
+        task_id (int):
+        completed (Union[Unset, bool]):  Default: False.
+    """
+
+    title: str
+    id: int
+    task_id: int
+    completed: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        id = self.id
+
+        task_id = self.task_id
+
+        completed = self.completed
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "id": id,
+                "task_id": task_id,
+            }
+        )
+        if completed is not UNSET:
+            field_dict["completed"] = completed
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        id = d.pop("id")
+
+        task_id = d.pop("task_id")
+
+        completed = d.pop("completed", UNSET)
+
+        subtask = cls(
+            title=title,
+            id=id,
+            task_id=task_id,
+            completed=completed,
+        )
+
+        subtask.additional_properties = d
+        return subtask
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/subtask_create.py
+++ b/openapi_client/fast_api_client/models/subtask_create.py
@@ -1,0 +1,70 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SubtaskCreate")
+
+
+@_attrs_define
+class SubtaskCreate:
+    """
+    Attributes:
+        title (str):
+        completed (Union[Unset, bool]):  Default: False.
+    """
+
+    title: str
+    completed: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        completed = self.completed
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+            }
+        )
+        if completed is not UNSET:
+            field_dict["completed"] = completed
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        completed = d.pop("completed", UNSET)
+
+        subtask_create = cls(
+            title=title,
+            completed=completed,
+        )
+
+        subtask_create.additional_properties = d
+        return subtask_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/subtask_update.py
+++ b/openapi_client/fast_api_client/models/subtask_update.py
@@ -1,0 +1,70 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="SubtaskUpdate")
+
+
+@_attrs_define
+class SubtaskUpdate:
+    """
+    Attributes:
+        title (str):
+        completed (Union[Unset, bool]):  Default: False.
+    """
+
+    title: str
+    completed: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        completed = self.completed
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+            }
+        )
+        if completed is not UNSET:
+            field_dict["completed"] = completed
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        completed = d.pop("completed", UNSET)
+
+        subtask_update = cls(
+            title=title,
+            completed=completed,
+        )
+
+        subtask_update.additional_properties = d
+        return subtask_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/task.py
+++ b/openapi_client/fast_api_client/models/task.py
@@ -1,0 +1,306 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="Task")
+
+
+@_attrs_define
+class Task:
+    """
+    Attributes:
+        title (str):
+        due_date (datetime.date):
+        id (int):
+        description (Union[None, Unset, str]):
+        start_date (Union[None, Unset, datetime.date]):
+        end_date (Union[None, Unset, datetime.date]):
+        start_time (Union[None, Unset, str]):
+        end_time (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        perceived_difficulty (Union[None, Unset, int]):
+        estimated_difficulty (Union[None, Unset, int]):
+        estimated_duration_minutes (Union[None, Unset, int]):
+        priority (Union[Unset, int]):  Default: 3.
+        worked_on (Union[Unset, bool]):  Default: False.
+        paused (Union[Unset, bool]):  Default: False.
+    """
+
+    title: str
+    due_date: datetime.date
+    id: int
+    description: Union[None, Unset, str] = UNSET
+    start_date: Union[None, Unset, datetime.date] = UNSET
+    end_date: Union[None, Unset, datetime.date] = UNSET
+    start_time: Union[None, Unset, str] = UNSET
+    end_time: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    perceived_difficulty: Union[None, Unset, int] = UNSET
+    estimated_difficulty: Union[None, Unset, int] = UNSET
+    estimated_duration_minutes: Union[None, Unset, int] = UNSET
+    priority: Union[Unset, int] = 3
+    worked_on: Union[Unset, bool] = False
+    paused: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        due_date = self.due_date.isoformat()
+
+        id = self.id
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        start_date: Union[None, Unset, str]
+        if isinstance(self.start_date, Unset):
+            start_date = UNSET
+        elif isinstance(self.start_date, datetime.date):
+            start_date = self.start_date.isoformat()
+        else:
+            start_date = self.start_date
+
+        end_date: Union[None, Unset, str]
+        if isinstance(self.end_date, Unset):
+            end_date = UNSET
+        elif isinstance(self.end_date, datetime.date):
+            end_date = self.end_date.isoformat()
+        else:
+            end_date = self.end_date
+
+        start_time: Union[None, Unset, str]
+        if isinstance(self.start_time, Unset):
+            start_time = UNSET
+        else:
+            start_time = self.start_time
+
+        end_time: Union[None, Unset, str]
+        if isinstance(self.end_time, Unset):
+            end_time = UNSET
+        else:
+            end_time = self.end_time
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        perceived_difficulty: Union[None, Unset, int]
+        if isinstance(self.perceived_difficulty, Unset):
+            perceived_difficulty = UNSET
+        else:
+            perceived_difficulty = self.perceived_difficulty
+
+        estimated_difficulty: Union[None, Unset, int]
+        if isinstance(self.estimated_difficulty, Unset):
+            estimated_difficulty = UNSET
+        else:
+            estimated_difficulty = self.estimated_difficulty
+
+        estimated_duration_minutes: Union[None, Unset, int]
+        if isinstance(self.estimated_duration_minutes, Unset):
+            estimated_duration_minutes = UNSET
+        else:
+            estimated_duration_minutes = self.estimated_duration_minutes
+
+        priority = self.priority
+
+        worked_on = self.worked_on
+
+        paused = self.paused
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "due_date": due_date,
+                "id": id,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if start_date is not UNSET:
+            field_dict["start_date"] = start_date
+        if end_date is not UNSET:
+            field_dict["end_date"] = end_date
+        if start_time is not UNSET:
+            field_dict["start_time"] = start_time
+        if end_time is not UNSET:
+            field_dict["end_time"] = end_time
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+        if perceived_difficulty is not UNSET:
+            field_dict["perceived_difficulty"] = perceived_difficulty
+        if estimated_difficulty is not UNSET:
+            field_dict["estimated_difficulty"] = estimated_difficulty
+        if estimated_duration_minutes is not UNSET:
+            field_dict["estimated_duration_minutes"] = estimated_duration_minutes
+        if priority is not UNSET:
+            field_dict["priority"] = priority
+        if worked_on is not UNSET:
+            field_dict["worked_on"] = worked_on
+        if paused is not UNSET:
+            field_dict["paused"] = paused
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        due_date = isoparse(d.pop("due_date")).date()
+
+        id = d.pop("id")
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_start_date(data: object) -> Union[None, Unset, datetime.date]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                start_date_type_0 = isoparse(data).date()
+
+                return start_date_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.date], data)
+
+        start_date = _parse_start_date(d.pop("start_date", UNSET))
+
+        def _parse_end_date(data: object) -> Union[None, Unset, datetime.date]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                end_date_type_0 = isoparse(data).date()
+
+                return end_date_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.date], data)
+
+        end_date = _parse_end_date(d.pop("end_date", UNSET))
+
+        def _parse_start_time(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        start_time = _parse_start_time(d.pop("start_time", UNSET))
+
+        def _parse_end_time(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        end_time = _parse_end_time(d.pop("end_time", UNSET))
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        def _parse_perceived_difficulty(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        perceived_difficulty = _parse_perceived_difficulty(d.pop("perceived_difficulty", UNSET))
+
+        def _parse_estimated_difficulty(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        estimated_difficulty = _parse_estimated_difficulty(d.pop("estimated_difficulty", UNSET))
+
+        def _parse_estimated_duration_minutes(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        estimated_duration_minutes = _parse_estimated_duration_minutes(d.pop("estimated_duration_minutes", UNSET))
+
+        priority = d.pop("priority", UNSET)
+
+        worked_on = d.pop("worked_on", UNSET)
+
+        paused = d.pop("paused", UNSET)
+
+        task = cls(
+            title=title,
+            due_date=due_date,
+            id=id,
+            description=description,
+            start_date=start_date,
+            end_date=end_date,
+            start_time=start_time,
+            end_time=end_time,
+            category_id=category_id,
+            perceived_difficulty=perceived_difficulty,
+            estimated_difficulty=estimated_difficulty,
+            estimated_duration_minutes=estimated_duration_minutes,
+            priority=priority,
+            worked_on=worked_on,
+            paused=paused,
+        )
+
+        task.additional_properties = d
+        return task
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/task_create.py
+++ b/openapi_client/fast_api_client/models/task_create.py
@@ -1,0 +1,298 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TaskCreate")
+
+
+@_attrs_define
+class TaskCreate:
+    """
+    Attributes:
+        title (str):
+        due_date (datetime.date):
+        description (Union[None, Unset, str]):
+        start_date (Union[None, Unset, datetime.date]):
+        end_date (Union[None, Unset, datetime.date]):
+        start_time (Union[None, Unset, str]):
+        end_time (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        perceived_difficulty (Union[None, Unset, int]):
+        estimated_difficulty (Union[None, Unset, int]):
+        estimated_duration_minutes (Union[None, Unset, int]):
+        priority (Union[Unset, int]):  Default: 3.
+        worked_on (Union[Unset, bool]):  Default: False.
+        paused (Union[Unset, bool]):  Default: False.
+    """
+
+    title: str
+    due_date: datetime.date
+    description: Union[None, Unset, str] = UNSET
+    start_date: Union[None, Unset, datetime.date] = UNSET
+    end_date: Union[None, Unset, datetime.date] = UNSET
+    start_time: Union[None, Unset, str] = UNSET
+    end_time: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    perceived_difficulty: Union[None, Unset, int] = UNSET
+    estimated_difficulty: Union[None, Unset, int] = UNSET
+    estimated_duration_minutes: Union[None, Unset, int] = UNSET
+    priority: Union[Unset, int] = 3
+    worked_on: Union[Unset, bool] = False
+    paused: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        due_date = self.due_date.isoformat()
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        start_date: Union[None, Unset, str]
+        if isinstance(self.start_date, Unset):
+            start_date = UNSET
+        elif isinstance(self.start_date, datetime.date):
+            start_date = self.start_date.isoformat()
+        else:
+            start_date = self.start_date
+
+        end_date: Union[None, Unset, str]
+        if isinstance(self.end_date, Unset):
+            end_date = UNSET
+        elif isinstance(self.end_date, datetime.date):
+            end_date = self.end_date.isoformat()
+        else:
+            end_date = self.end_date
+
+        start_time: Union[None, Unset, str]
+        if isinstance(self.start_time, Unset):
+            start_time = UNSET
+        else:
+            start_time = self.start_time
+
+        end_time: Union[None, Unset, str]
+        if isinstance(self.end_time, Unset):
+            end_time = UNSET
+        else:
+            end_time = self.end_time
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        perceived_difficulty: Union[None, Unset, int]
+        if isinstance(self.perceived_difficulty, Unset):
+            perceived_difficulty = UNSET
+        else:
+            perceived_difficulty = self.perceived_difficulty
+
+        estimated_difficulty: Union[None, Unset, int]
+        if isinstance(self.estimated_difficulty, Unset):
+            estimated_difficulty = UNSET
+        else:
+            estimated_difficulty = self.estimated_difficulty
+
+        estimated_duration_minutes: Union[None, Unset, int]
+        if isinstance(self.estimated_duration_minutes, Unset):
+            estimated_duration_minutes = UNSET
+        else:
+            estimated_duration_minutes = self.estimated_duration_minutes
+
+        priority = self.priority
+
+        worked_on = self.worked_on
+
+        paused = self.paused
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "due_date": due_date,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if start_date is not UNSET:
+            field_dict["start_date"] = start_date
+        if end_date is not UNSET:
+            field_dict["end_date"] = end_date
+        if start_time is not UNSET:
+            field_dict["start_time"] = start_time
+        if end_time is not UNSET:
+            field_dict["end_time"] = end_time
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+        if perceived_difficulty is not UNSET:
+            field_dict["perceived_difficulty"] = perceived_difficulty
+        if estimated_difficulty is not UNSET:
+            field_dict["estimated_difficulty"] = estimated_difficulty
+        if estimated_duration_minutes is not UNSET:
+            field_dict["estimated_duration_minutes"] = estimated_duration_minutes
+        if priority is not UNSET:
+            field_dict["priority"] = priority
+        if worked_on is not UNSET:
+            field_dict["worked_on"] = worked_on
+        if paused is not UNSET:
+            field_dict["paused"] = paused
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        due_date = isoparse(d.pop("due_date")).date()
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_start_date(data: object) -> Union[None, Unset, datetime.date]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                start_date_type_0 = isoparse(data).date()
+
+                return start_date_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.date], data)
+
+        start_date = _parse_start_date(d.pop("start_date", UNSET))
+
+        def _parse_end_date(data: object) -> Union[None, Unset, datetime.date]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                end_date_type_0 = isoparse(data).date()
+
+                return end_date_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.date], data)
+
+        end_date = _parse_end_date(d.pop("end_date", UNSET))
+
+        def _parse_start_time(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        start_time = _parse_start_time(d.pop("start_time", UNSET))
+
+        def _parse_end_time(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        end_time = _parse_end_time(d.pop("end_time", UNSET))
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        def _parse_perceived_difficulty(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        perceived_difficulty = _parse_perceived_difficulty(d.pop("perceived_difficulty", UNSET))
+
+        def _parse_estimated_difficulty(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        estimated_difficulty = _parse_estimated_difficulty(d.pop("estimated_difficulty", UNSET))
+
+        def _parse_estimated_duration_minutes(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        estimated_duration_minutes = _parse_estimated_duration_minutes(d.pop("estimated_duration_minutes", UNSET))
+
+        priority = d.pop("priority", UNSET)
+
+        worked_on = d.pop("worked_on", UNSET)
+
+        paused = d.pop("paused", UNSET)
+
+        task_create = cls(
+            title=title,
+            due_date=due_date,
+            description=description,
+            start_date=start_date,
+            end_date=end_date,
+            start_time=start_time,
+            end_time=end_time,
+            category_id=category_id,
+            perceived_difficulty=perceived_difficulty,
+            estimated_difficulty=estimated_difficulty,
+            estimated_duration_minutes=estimated_duration_minutes,
+            priority=priority,
+            worked_on=worked_on,
+            paused=paused,
+        )
+
+        task_create.additional_properties = d
+        return task_create
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/task_update.py
+++ b/openapi_client/fast_api_client/models/task_update.py
@@ -1,0 +1,298 @@
+import datetime
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+from dateutil.parser import isoparse
+
+from ..types import UNSET, Unset
+
+T = TypeVar("T", bound="TaskUpdate")
+
+
+@_attrs_define
+class TaskUpdate:
+    """
+    Attributes:
+        title (str):
+        due_date (datetime.date):
+        description (Union[None, Unset, str]):
+        start_date (Union[None, Unset, datetime.date]):
+        end_date (Union[None, Unset, datetime.date]):
+        start_time (Union[None, Unset, str]):
+        end_time (Union[None, Unset, str]):
+        category_id (Union[None, Unset, int]):
+        perceived_difficulty (Union[None, Unset, int]):
+        estimated_difficulty (Union[None, Unset, int]):
+        estimated_duration_minutes (Union[None, Unset, int]):
+        priority (Union[Unset, int]):  Default: 3.
+        worked_on (Union[Unset, bool]):  Default: False.
+        paused (Union[Unset, bool]):  Default: False.
+    """
+
+    title: str
+    due_date: datetime.date
+    description: Union[None, Unset, str] = UNSET
+    start_date: Union[None, Unset, datetime.date] = UNSET
+    end_date: Union[None, Unset, datetime.date] = UNSET
+    start_time: Union[None, Unset, str] = UNSET
+    end_time: Union[None, Unset, str] = UNSET
+    category_id: Union[None, Unset, int] = UNSET
+    perceived_difficulty: Union[None, Unset, int] = UNSET
+    estimated_difficulty: Union[None, Unset, int] = UNSET
+    estimated_duration_minutes: Union[None, Unset, int] = UNSET
+    priority: Union[Unset, int] = 3
+    worked_on: Union[Unset, bool] = False
+    paused: Union[Unset, bool] = False
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        title = self.title
+
+        due_date = self.due_date.isoformat()
+
+        description: Union[None, Unset, str]
+        if isinstance(self.description, Unset):
+            description = UNSET
+        else:
+            description = self.description
+
+        start_date: Union[None, Unset, str]
+        if isinstance(self.start_date, Unset):
+            start_date = UNSET
+        elif isinstance(self.start_date, datetime.date):
+            start_date = self.start_date.isoformat()
+        else:
+            start_date = self.start_date
+
+        end_date: Union[None, Unset, str]
+        if isinstance(self.end_date, Unset):
+            end_date = UNSET
+        elif isinstance(self.end_date, datetime.date):
+            end_date = self.end_date.isoformat()
+        else:
+            end_date = self.end_date
+
+        start_time: Union[None, Unset, str]
+        if isinstance(self.start_time, Unset):
+            start_time = UNSET
+        else:
+            start_time = self.start_time
+
+        end_time: Union[None, Unset, str]
+        if isinstance(self.end_time, Unset):
+            end_time = UNSET
+        else:
+            end_time = self.end_time
+
+        category_id: Union[None, Unset, int]
+        if isinstance(self.category_id, Unset):
+            category_id = UNSET
+        else:
+            category_id = self.category_id
+
+        perceived_difficulty: Union[None, Unset, int]
+        if isinstance(self.perceived_difficulty, Unset):
+            perceived_difficulty = UNSET
+        else:
+            perceived_difficulty = self.perceived_difficulty
+
+        estimated_difficulty: Union[None, Unset, int]
+        if isinstance(self.estimated_difficulty, Unset):
+            estimated_difficulty = UNSET
+        else:
+            estimated_difficulty = self.estimated_difficulty
+
+        estimated_duration_minutes: Union[None, Unset, int]
+        if isinstance(self.estimated_duration_minutes, Unset):
+            estimated_duration_minutes = UNSET
+        else:
+            estimated_duration_minutes = self.estimated_duration_minutes
+
+        priority = self.priority
+
+        worked_on = self.worked_on
+
+        paused = self.paused
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "title": title,
+                "due_date": due_date,
+            }
+        )
+        if description is not UNSET:
+            field_dict["description"] = description
+        if start_date is not UNSET:
+            field_dict["start_date"] = start_date
+        if end_date is not UNSET:
+            field_dict["end_date"] = end_date
+        if start_time is not UNSET:
+            field_dict["start_time"] = start_time
+        if end_time is not UNSET:
+            field_dict["end_time"] = end_time
+        if category_id is not UNSET:
+            field_dict["category_id"] = category_id
+        if perceived_difficulty is not UNSET:
+            field_dict["perceived_difficulty"] = perceived_difficulty
+        if estimated_difficulty is not UNSET:
+            field_dict["estimated_difficulty"] = estimated_difficulty
+        if estimated_duration_minutes is not UNSET:
+            field_dict["estimated_duration_minutes"] = estimated_duration_minutes
+        if priority is not UNSET:
+            field_dict["priority"] = priority
+        if worked_on is not UNSET:
+            field_dict["worked_on"] = worked_on
+        if paused is not UNSET:
+            field_dict["paused"] = paused
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        title = d.pop("title")
+
+        due_date = isoparse(d.pop("due_date")).date()
+
+        def _parse_description(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        description = _parse_description(d.pop("description", UNSET))
+
+        def _parse_start_date(data: object) -> Union[None, Unset, datetime.date]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                start_date_type_0 = isoparse(data).date()
+
+                return start_date_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.date], data)
+
+        start_date = _parse_start_date(d.pop("start_date", UNSET))
+
+        def _parse_end_date(data: object) -> Union[None, Unset, datetime.date]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                end_date_type_0 = isoparse(data).date()
+
+                return end_date_type_0
+            except:  # noqa: E722
+                pass
+            return cast(Union[None, Unset, datetime.date], data)
+
+        end_date = _parse_end_date(d.pop("end_date", UNSET))
+
+        def _parse_start_time(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        start_time = _parse_start_time(d.pop("start_time", UNSET))
+
+        def _parse_end_time(data: object) -> Union[None, Unset, str]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, str], data)
+
+        end_time = _parse_end_time(d.pop("end_time", UNSET))
+
+        def _parse_category_id(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        category_id = _parse_category_id(d.pop("category_id", UNSET))
+
+        def _parse_perceived_difficulty(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        perceived_difficulty = _parse_perceived_difficulty(d.pop("perceived_difficulty", UNSET))
+
+        def _parse_estimated_difficulty(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        estimated_difficulty = _parse_estimated_difficulty(d.pop("estimated_difficulty", UNSET))
+
+        def _parse_estimated_duration_minutes(data: object) -> Union[None, Unset, int]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            return cast(Union[None, Unset, int], data)
+
+        estimated_duration_minutes = _parse_estimated_duration_minutes(d.pop("estimated_duration_minutes", UNSET))
+
+        priority = d.pop("priority", UNSET)
+
+        worked_on = d.pop("worked_on", UNSET)
+
+        paused = d.pop("paused", UNSET)
+
+        task_update = cls(
+            title=title,
+            due_date=due_date,
+            description=description,
+            start_date=start_date,
+            end_date=end_date,
+            start_time=start_time,
+            end_time=end_time,
+            category_id=category_id,
+            perceived_difficulty=perceived_difficulty,
+            estimated_difficulty=estimated_difficulty,
+            estimated_duration_minutes=estimated_duration_minutes,
+            priority=priority,
+            worked_on=worked_on,
+            paused=paused,
+        )
+
+        task_update.additional_properties = d
+        return task_update
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/models/validation_error.py
+++ b/openapi_client/fast_api_client/models/validation_error.py
@@ -1,0 +1,88 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Union, cast
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="ValidationError")
+
+
+@_attrs_define
+class ValidationError:
+    """
+    Attributes:
+        loc (list[Union[int, str]]):
+        msg (str):
+        type_ (str):
+    """
+
+    loc: list[Union[int, str]]
+    msg: str
+    type_: str
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        loc = []
+        for loc_item_data in self.loc:
+            loc_item: Union[int, str]
+            loc_item = loc_item_data
+            loc.append(loc_item)
+
+        msg = self.msg
+
+        type_ = self.type_
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "loc": loc,
+                "msg": msg,
+                "type": type_,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        loc = []
+        _loc = d.pop("loc")
+        for loc_item_data in _loc:
+
+            def _parse_loc_item(data: object) -> Union[int, str]:
+                return cast(Union[int, str], data)
+
+            loc_item = _parse_loc_item(loc_item_data)
+
+            loc.append(loc_item)
+
+        msg = d.pop("msg")
+
+        type_ = d.pop("type")
+
+        validation_error = cls(
+            loc=loc,
+            msg=msg,
+            type_=type_,
+        )
+
+        validation_error.additional_properties = d
+        return validation_error
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/openapi_client/fast_api_client/py.typed
+++ b/openapi_client/fast_api_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/openapi_client/fast_api_client/types.py
+++ b/openapi_client/fast_api_client/types.py
@@ -1,0 +1,54 @@
+"""Contains some shared types for properties"""
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import IO, BinaryIO, Generic, Literal, Optional, TypeVar, Union
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = Union[IO[bytes], bytes, str]
+FileTypes = Union[
+    # (filename, file (or bytes), content_type)
+    tuple[Optional[str], FileContent, Optional[str]],
+    # (filename, file (or bytes), content_type, headers)
+    tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
+]
+RequestFiles = list[tuple[str, FileTypes]]
+
+
+@define
+class File:
+    """Contains information for file uploads"""
+
+    payload: BinaryIO
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
+
+    def to_tuple(self) -> FileTypes:
+        """Return a tuple representation that httpx will accept for multipart/form-data"""
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """A response from an endpoint"""
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/openapi_client/pyproject.toml
+++ b/openapi_client/pyproject.toml
@@ -1,0 +1,27 @@
+[tool.poetry]
+name = "fast-api-client"
+version = "0.1.0"
+description = "A client library for accessing FastAPI"
+authors = []
+readme = "README.md"
+packages = [
+    {include = "fast_api_client"},
+]
+include = ["CHANGELOG.md", "fast_api_client/py.typed"]
+
+
+[tool.poetry.dependencies]
+python = "^3.9"
+httpx = ">=0.23.0,<0.29.0"
+attrs = ">=22.2.0"
+python-dateutil = "^2.8.0"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["F", "I", "UP"]


### PR DESCRIPTION
## Summary
- generate `openapi_client` from OpenAPI spec
- add logging configuration options
- create GitHub Actions workflow
- document logging and API client usage in README
- update TODO list

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68847e4196908327932ce35d0b573262