### PR TITLE
Implement dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Set the log level with `LOG_LEVEL` in `config.yaml` or as an environment variabl
 streamlit run streamlit_app.py
 ```
 
+### Dark Mode
+
+The GUI supports an optional dark theme. Enable it via the **Dark Mode**
+checkbox at the top of the application.
+
 ## Running Tests
 
 To run all tests:

--- a/TODO.md
+++ b/TODO.md
@@ -24,7 +24,7 @@ The following steps aim to enhance the calendar and task planning application. E
 20. [ ] Add time zone handling for appointments
 21. [ ] Support multiple languages in the GUI
 22. [ ] Improve accessibility with ARIA labels
-23. [ ] Add dark mode theme option
+23. [x] Add dark mode theme option
 24. [ ] Provide keyboard shortcuts for quick actions
 25. [ ] Improve mobile responsiveness of GUI
 26. [ ] Add offline support with local storage

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -12,6 +12,33 @@ API_URL = "http://localhost:8000"
 
 st.title("Calendar App")
 
+if "dark-mode" not in st.session_state:
+    st.session_state["dark-mode"] = False
+
+st.checkbox("Dark Mode", key="dark-mode")
+
+def apply_theme() -> None:
+    """Apply light or dark theme based on session state."""
+    if st.session_state["dark-mode"]:
+        bg = "#0e1117"
+        fg = "#ffffff"
+    else:
+        bg = "#ffffff"
+        fg = "#000000"
+    st.markdown(
+        f"""
+        <style>
+        html, body, [data-testid="stApp"] {{
+            background-color: {bg};
+            color: {fg};
+        }}
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+apply_theme()
+
 if "appointments" not in st.session_state:
     st.session_state["appointments"] = []
 if "categories" not in st.session_state:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -45,6 +45,9 @@ def test_full_gui_interaction():
     try:
         at = AppTest.from_file("streamlit_app.py").run()
 
+        # enable dark mode
+        at = at.checkbox(key="dark-mode").check().run()
+
         # create category
         cat_tab = next(t for t in at.tabs if t.label == "Manage Categories")
         at = cat_tab.text_input(key="cat-name").input("Work").run()


### PR DESCRIPTION
## Summary
- add dark mode checkbox in `streamlit_app.py` with CSS style
- document dark mode in README
- mark TODO entry for dark mode as complete
- update GUI test to cover dark mode

## Testing
- `pip install -r requirements.txt`
- `pytest tests/test_gui.py::test_full_gui_interaction -q`

------
https://chatgpt.com/codex/tasks/task_e_6888924356508327b9e0bfc87a1a100c