### PR TITLE
Implement admin metrics dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ The `openapi_client` package is generated from the OpenAPI schema using `openapi
 ```bash
 openapi-python-client generate --url http://localhost:8000/openapi.json --output-path openapi_client
 ```
+## Metrics
+A Prometheus metrics endpoint is available at `/admin/metrics`.
+The Streamlit GUI includes an "Admin Dashboard" tab displaying task, appointment and category counts.
+
 
 
 ## Docker Compose

--- a/TODO.md
+++ b/TODO.md
@@ -49,8 +49,8 @@ The following steps aim to enhance the calendar and task planning application. E
 45. [x] Introduce dataclasses where appropriate
 46. [ ] Refactor large functions into smaller units
 47. [x] Add logging configuration options
-48. [ ] Create admin dashboard for system metrics
-49. [ ] Expose Prometheus metrics endpoint
+48. [x] Create admin dashboard for system metrics
+49. [x] Expose Prometheus metrics endpoint
 50. [ ] Add Grafana dashboards
 51. [ ] Implement user permissions and roles
 52. [ ] Add sharing of tasks with other users

--- a/app/main.py
+++ b/app/main.py
@@ -7,6 +7,7 @@ from fastapi import Depends, FastAPI, HTTPException
 from sqlalchemy.orm import Session
 
 from . import models, schemas
+from .metrics import MetricsService
 from .database import Base, SessionLocal, engine
 from .config import ConfigLoader, setup_logging
 
@@ -1742,3 +1743,15 @@ def delete_focus_session(task_id: int, session_id: int, db: Session = Depends(ge
     service = FocusSessionService(db)
     service.delete(task_id, session_id)
     return {"detail": "Deleted"}
+
+
+@app.get("/admin/stats")
+def get_stats(db: Session = Depends(get_db)):
+    service = MetricsService(db)
+    return service.stats()
+
+
+@app.get("/admin/metrics")
+def prometheus_metrics(db: Session = Depends(get_db)):
+    service = MetricsService(db)
+    return service.prometheus()

--- a/app/metrics.py
+++ b/app/metrics.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from fastapi import Response
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Gauge,
+    generate_latest,
+)
+from sqlalchemy.orm import Session
+
+from . import models
+from .database import SessionLocal
+
+
+class MetricsService:
+    """Collect and expose application metrics."""
+
+    _registry = CollectorRegistry()
+    _task_gauge = Gauge(
+        "tasks_total",
+        "Total number of tasks",
+        registry=_registry,
+    )
+    _appt_gauge = Gauge(
+        "appointments_total",
+        "Total number of appointments",
+        registry=_registry,
+    )
+    _category_gauge = Gauge(
+        "categories_total",
+        "Total number of categories",
+        registry=_registry,
+    )
+
+    def __init__(self, db: Session | None = None) -> None:
+        self.db = db or SessionLocal()
+
+    def _update_gauges(self) -> None:
+        self._task_gauge.set(self.db.query(models.Task).count())
+        self._appt_gauge.set(self.db.query(models.Appointment).count())
+        self._category_gauge.set(self.db.query(models.Category).count())
+
+    def stats(self) -> dict[str, int]:
+        self._update_gauges()
+        return {
+            "tasks": int(self._task_gauge._value.get()),
+            "appointments": int(self._appt_gauge._value.get()),
+            "categories": int(self._category_gauge._value.get()),
+        }
+
+    def prometheus(self) -> Response:
+        self._update_gauges()
+        return Response(generate_latest(self._registry), media_type=CONTENT_TYPE_LATEST)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ streamlit-calendar
 pyyaml
 psycopg2-binary
 alembic
+prometheus_client

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -51,6 +51,8 @@ if "calendar_date" not in st.session_state:
     st.session_state["calendar_date"] = date.today()
 
 
+if "stats" not in st.session_state:
+    st.session_state["stats"] = {}
 def refresh():
     resp = requests.get(f"{API_URL}/appointments")
     if resp.status_code == 200:
@@ -75,7 +77,14 @@ def refresh_tasks():
         st.session_state["tasks"] = tasks
 
 
+def refresh_stats():
+    resp = requests.get(f"{API_URL}/admin/stats")
+    if resp.status_code == 200:
+        st.session_state["stats"] = resp.json()
+
+
 refresh()
+refresh_stats()
 refresh_categories()
 refresh_tasks()
 
@@ -84,6 +93,7 @@ tabs = st.tabs(
     [
         "Manage Appointments",
         "Manage Tasks",
+        "Admin Dashboard",
         "Calendar",
         "Manage Categories",
     ]
@@ -628,8 +638,14 @@ with tabs[1]:
                     refresh_tasks()
                 else:
                     st.error("Error deleting task")
-
 with tabs[2]:
+    refresh_stats()
+    st.header("System Metrics")
+    st.metric("Tasks", st.session_state["stats"].get("tasks", 0))
+    st.metric("Appointments", st.session_state["stats"].get("appointments", 0))
+    st.metric("Categories", st.session_state["stats"].get("categories", 0))
+
+with tabs[3]:
     view = st.selectbox(
         "View",
         ["Day", "Week", "Two Weeks", "Month"],
@@ -762,7 +778,7 @@ with tabs[2]:
                 refresh()
                 break
 
-with tabs[3]:
+with tabs[4]:
     st.header("Create Category")
     with st.form("cat-form"):
         name = st.text_input("Name", key="cat-name")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1406,3 +1406,13 @@ def test_session_count_weight(monkeypatch):
         ]
     ).date()
     assert second_day > first_day
+
+def test_admin_stats_and_metrics():
+    r = requests.get(f"{API_URL}/admin/stats")
+    assert r.status_code == 200
+    data = r.json()
+    assert set(data.keys()) == {"tasks", "appointments", "categories"}
+
+    r = requests.get(f"{API_URL}/admin/metrics")
+    assert r.status_code == 200
+    assert "tasks_total" in r.text


### PR DESCRIPTION
## Summary
- add metrics collection via Prometheus
- expose `/admin/stats` and `/admin/metrics` endpoints
- create MetricsService class
- display metrics in new **Admin Dashboard** tab in Streamlit GUI
- document metrics in README
- mark TODOs as complete
- add tests for metrics endpoints

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888971c8a78832797753a47729bdf53